### PR TITLE
migrate src and tests from previous project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ CMakeUserPresets.json
 *~
 _ReSharper*
 *.log
+compile_commands.json
+.cache/
 
 # OS Generated Files
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.21)
 # manual dependency management
 
 # Only set the cxx_standard if it is not set by someone else
-if (NOT DEFINED CMAKE_CXX_STANDARD)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 23)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,254 +1,260 @@
 {
-    "version": 3,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 21,
-        "patch": 0
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "conf-common",
+      "description": "General settings that apply to all configurations",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
-    "configurePresets": [
-        {
-            "name": "conf-common",
-            "description": "General settings that apply to all configurations",
-            "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}"
-        },
-        {
-            "name": "conf-windows-common",
-            "description": "Windows settings for MSBuild toolchain that apply to msvc and clang",
-            "hidden": true,
-            "inherits": "conf-common",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "toolset": {
-                "value": "host=x64",
-                "strategy": "external"
-            },
-            "cacheVariables": {
-                "ENABLE_CPPCHECK_DEFAULT": "FALSE",
-                "ENABLE_CLANG_TIDY_DEFAULT": "FALSE"
-            }
-        },
-        {
-            "name": "conf-unixlike-common",
-            "description": "Unix-like OS settings for gcc and clang toolchains",
-            "hidden": true,
-            "inherits": "conf-common",
-            "condition": {
-                "type": "inList",
-                "string": "${hostSystemName}",
-                "list": [
-                    "Linux",
-                    "Darwin"
-                ]
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
-                    "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
-                }
-            }
-        },
-        {
-            "name": "windows-msvc-debug-developer-mode",
-            "displayName": "msvc Debug (Developer Mode)",
-            "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "ON"
-            }
-        },
-        {
-            "name": "windows-msvc-release-developer-mode",
-            "displayName": "msvc Release (Developer Mode)",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "ON"
-            }
-        },
-        {
-            "name": "windows-msvc-debug-user-mode",
-            "displayName": "msvc Debug (User Mode)",
-            "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "OFF"
-            }
-        },
-        {
-            "name": "windows-msvc-release-user-mode",
-            "displayName": "msvc Release (User Mode)",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "OFF"
-            }
-        },
-        {
-            "name": "windows-clang-debug",
-            "displayName": "clang Debug",
-            "description": "Target Windows with the clang compiler, debug build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_BUILD_TYPE": "Debug"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-clang-x64"
-                }
-            }
-        },
-        {
-            "name": "windows-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Windows with the clang compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-clang-x64"
-                }
-            }
-        },
-        {
-            "name": "unixlike-gcc-debug",
-            "displayName": "gcc Debug",
-            "description": "Target Unix-like OS with the gcc compiler, debug build type",
-            "inherits": "conf-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "unixlike-gcc-release",
-            "displayName": "gcc Release",
-            "description": "Target Unix-like OS with the gcc compiler, release build type",
-            "inherits": "conf-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "unixlike-clang-debug",
-            "displayName": "clang Debug",
-            "description": "Target Unix-like OS with the clang compiler, debug build type",
-            "inherits": "conf-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "unixlike-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Unix-like OS with the clang compiler, release build type",
-            "inherits": "conf-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
+    {
+      "name": "conf-windows-common",
+      "description": "Windows settings for MSBuild toolchain that apply to msvc and clang",
+      "hidden": true,
+      "inherits": "conf-common",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "ENABLE_CPPCHECK_DEFAULT": "FALSE",
+        "ENABLE_CLANG_TIDY_DEFAULT": "FALSE"
+      }
+    },
+    {
+      "name": "conf-unixlike-common",
+      "description": "Unix-like OS settings for gcc and clang toolchains",
+      "hidden": true,
+      "inherits": "conf-common",
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": [
+          "Linux",
+          "Darwin"
+        ]
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
         }
-    ],
-    "testPresets": [
-        {
-            "name": "test-common",
-            "description": "Test CMake settings that apply to all configurations",
-            "hidden": true,
-            "output": {
-                "outputOnFailure": true
-            },
-            "execution": {
-                "noTestsAction": "error",
-                "stopOnFailure": true
-            }
-        },
-        {
-            "name": "test-windows-msvc-debug-developer-mode",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug-developer-mode"
-        },
-        {
-            "name": "test-windows-msvc-release-developer-mode",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-msvc-release-developer-mode"
-        },
-        {
-            "name": "test-windows-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-debug"
-        },
-        {
-            "name": "test-windows-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-release"
-        },
-        {
-            "name": "test-unixlike-gcc-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-debug"
-        },
-        {
-            "name": "test-unixlike-gcc-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-release"
-        },
-        {
-            "name": "test-unixlike-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-clang-debug"
-        },
-        {
-            "name": "test-unixlike-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-clang-release"
+      }
+    },
+    {
+      "name": "windows-msvc-debug-developer-mode",
+      "displayName": "msvc Debug (Developer Mode)",
+      "description": "Target Windows with the msvc compiler, debug build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_DEVELOPER_MODE": "ON"
+      }
+    },
+    {
+      "name": "windows-msvc-release-developer-mode",
+      "displayName": "msvc Release (Developer Mode)",
+      "description": "Target Windows with the msvc compiler, release build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_DEVELOPER_MODE": "ON"
+      }
+    },
+    {
+      "name": "windows-msvc-debug-user-mode",
+      "displayName": "msvc Debug (User Mode)",
+      "description": "Target Windows with the msvc compiler, debug build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_DEVELOPER_MODE": "OFF"
+      }
+    },
+    {
+      "name": "windows-msvc-release-user-mode",
+      "displayName": "msvc Release (User Mode)",
+      "description": "Target Windows with the msvc compiler, release build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_DEVELOPER_MODE": "OFF"
+      }
+    },
+    {
+      "name": "windows-clang-debug",
+      "displayName": "clang Debug",
+      "description": "Target Windows with the clang compiler, debug build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-clang-x64"
         }
-    ]
+      }
+    },
+    {
+      "name": "windows-clang-release",
+      "displayName": "clang Release",
+      "description": "Target Windows with the clang compiler, release build type",
+      "inherits": "conf-windows-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-clang-x64"
+        }
+      }
+    },
+    {
+      "name": "unixlike-gcc-debug",
+      "displayName": "gcc Debug",
+      "description": "Target Unix-like OS with the gcc compiler, debug build type",
+      "inherits": "conf-unixlike-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "unixlike-gcc-release",
+      "displayName": "gcc Release",
+      "description": "Target Unix-like OS with the gcc compiler, release build type",
+      "inherits": "conf-unixlike-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "unixlike-clang-debug",
+      "displayName": "clang Debug",
+      "description": "Target Unix-like OS with the clang compiler, debug build type",
+      "inherits": "conf-unixlike-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "unixlike-clang-release",
+      "displayName": "clang Release",
+      "description": "Target Unix-like OS with the clang compiler, release build type",
+      "inherits": "conf-unixlike-common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "unixlike-gcc-debug",
+      "configurePreset": "unixlike-gcc-debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test-common",
+      "description": "Test CMake settings that apply to all configurations",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "test-windows-msvc-debug-developer-mode",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "windows-msvc-debug-developer-mode"
+    },
+    {
+      "name": "test-windows-msvc-release-developer-mode",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "windows-msvc-release-developer-mode"
+    },
+    {
+      "name": "test-windows-clang-debug",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "windows-clang-debug"
+    },
+    {
+      "name": "test-windows-clang-release",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "windows-clang-release"
+    },
+    {
+      "name": "test-unixlike-gcc-debug",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "unixlike-gcc-debug"
+    },
+    {
+      "name": "test-unixlike-gcc-release",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "unixlike-gcc-release"
+    },
+    {
+      "name": "test-unixlike-clang-debug",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "unixlike-clang-debug"
+    },
+    {
+      "name": "test-unixlike-clang-release",
+      "displayName": "Strict",
+      "description": "Enable output and stop on failure",
+      "inherits": "test-common",
+      "configurePreset": "unixlike-clang-release"
+    }
+  ]
 }

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -40,4 +40,8 @@ function(dlt_explorer_setup_dependencies)
     cpmaddpackage("gh:lefticus/tools#update_build_system")
   endif()
 
+  if(dlt_explorer_ENABLE_DLT_DAEMON)
+    cpmaddpackage("gh:COVESA/dlt-daemon@2.18.10")
+  endif()
+
 endfunction()

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -80,6 +80,8 @@ macro(dlt_explorer_setup_options)
     option(dlt_explorer_ENABLE_CPPCHECK "Enable cpp-check analysis" OFF)
     option(dlt_explorer_ENABLE_PCH "Enable precompiled headers" OFF)
     option(dlt_explorer_ENABLE_CACHE "Enable ccache" OFF)
+    option(dlt_explorer_ENABLE_DLT_DAEMON "Build using dlt-daemon external dependency" OFF)
+    option(dlt_explorer_ENABLE_BENCHMARK "Build benchmark" OFF)
   else()
     option(dlt_explorer_ENABLE_IPO "Enable IPO/LTO" ON)
     option(dlt_explorer_WARNINGS_AS_ERRORS "Treat Warnings As Errors" ON)
@@ -94,6 +96,8 @@ macro(dlt_explorer_setup_options)
     option(dlt_explorer_ENABLE_CPPCHECK "Enable cpp-check analysis" ON)
     option(dlt_explorer_ENABLE_PCH "Enable precompiled headers" OFF)
     option(dlt_explorer_ENABLE_CACHE "Enable ccache" ON)
+    option(dlt_explorer_ENABLE_DLT_DAEMON "Build using dlt-daemon external dependency" ON)
+    option(dlt_explorer_ENABLE_BENCHMARK "Build benchmark" OFF)
   endif()
 
   if(NOT PROJECT_IS_TOP_LEVEL)
@@ -135,7 +139,7 @@ macro(dlt_explorer_global_options)
 
   if(dlt_explorer_ENABLE_HARDENING AND dlt_explorer_ENABLE_GLOBAL_HARDENING)
     include(cmake/Hardening.cmake)
-    if(NOT SUPPORTS_UBSAN 
+    if(NOT SUPPORTS_UBSAN
        OR dlt_explorer_ENABLE_SANITIZER_UNDEFINED
        OR dlt_explorer_ENABLE_SANITIZER_ADDRESS
        OR dlt_explorer_ENABLE_SANITIZER_THREAD
@@ -221,7 +225,7 @@ macro(dlt_explorer_local_options)
 
   if(dlt_explorer_ENABLE_HARDENING AND NOT dlt_explorer_ENABLE_GLOBAL_HARDENING)
     include(cmake/Hardening.cmake)
-    if(NOT SUPPORTS_UBSAN 
+    if(NOT SUPPORTS_UBSAN
        OR dlt_explorer_ENABLE_SANITIZER_UNDEFINED
        OR dlt_explorer_ENABLE_SANITIZER_ADDRESS
        OR dlt_explorer_ENABLE_SANITIZER_THREAD

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![CodeQL](https://github.com/RuiMarioCosta/dlt-explorer/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/RuiMarioCosta/dlt-explorer/actions/workflows/codeql-analysis.yml)
 
 ## About dlt-explorer
-App for visualizing and exploring DLT files
 
+App for visualizing and exploring DLT files
 
 ## More Details
 
- * [Dependency Setup](README_dependencies.md)
- * [Building Details](README_building.md)
- * [Troubleshooting](README_troubleshooting.md)
- * [Docker](README_docker.md)
+* [Dependency Setup](README_dependencies.md)
+* [Building Details](README_building.md)
+* [Troubleshooting](README_troubleshooting.md)
+* [Docker](README_docker.md)

--- a/README_building.md
+++ b/README_building.md
@@ -1,6 +1,7 @@
 ## Build Instructions
 
 A full build has different steps:
+
 1) Specifying the compiler using environment variables
 2) Configuring the project
 3) Building the project
@@ -13,72 +14,70 @@ By default (if you don't set environment variables `CC` and `CXX`), the system d
 
 CMake uses the environment variables CC and CXX to decide which compiler to use. So to avoid the conflict issues only specify the compilers using these variables.
 
-
 <details>
 <summary>Commands for setting the compilers </summary>
 
 - Debian/Ubuntu/MacOS:
 
-	Set your desired compiler (`clang`, `gcc`, etc):
+ Set your desired compiler (`clang`, `gcc`, etc):
 
-	- Temporarily (only for the current shell)
+ 	- Temporarily (only for the current shell)
 
-		Run one of the followings in the terminal:
+  Run one of the followings in the terminal:
 
-		- clang
+  		- clang
 
-				CC=clang CXX=clang++
+    CC=clang CXX=clang++
 
-		- gcc
+  		- gcc
 
-				CC=gcc CXX=g++
+    CC=gcc CXX=g++
 
-	- Permanent:
+ 	- Permanent:
 
-		Open `~/.bashrc` using your text editor:
+  Open `~/.bashrc` using your text editor:
 
-			gedit ~/.bashrc
+   gedit ~/.bashrc
 
-		Add `CC` and `CXX` to point to the compilers:
+  Add `CC` and `CXX` to point to the compilers:
 
-			export CC=clang
-			export CXX=clang++
+   export CC=clang
+   export CXX=clang++
 
-		Save and close the file.
+  Save and close the file.
 
 - Windows:
 
-	- Permanent:
+ 	- Permanent:
 
-		Run one of the followings in PowerShell:
+  Run one of the followings in PowerShell:
 
-		- Visual Studio generator and compiler (cl)
+  		- Visual Studio generator and compiler (cl)
 
-				[Environment]::SetEnvironmentVariable("CC", "cl.exe", "User")
-				[Environment]::SetEnvironmentVariable("CXX", "cl.exe", "User")
-				refreshenv
+    [Environment]::SetEnvironmentVariable("CC", "cl.exe", "User")
+    [Environment]::SetEnvironmentVariable("CXX", "cl.exe", "User")
+    refreshenv
 
-		  Set the architecture using [vcvarsall](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#vcvarsall-syntax):
+    Set the architecture using [vcvarsall](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#vcvarsall-syntax):
 
-				vcvarsall.bat x64
+    vcvarsall.bat x64
 
-		- clang
+  		- clang
 
-				[Environment]::SetEnvironmentVariable("CC", "clang.exe", "User")
-				[Environment]::SetEnvironmentVariable("CXX", "clang++.exe", "User")
-				refreshenv
+    [Environment]::SetEnvironmentVariable("CC", "clang.exe", "User")
+    [Environment]::SetEnvironmentVariable("CXX", "clang++.exe", "User")
+    refreshenv
 
-		- gcc
+  		- gcc
 
-				[Environment]::SetEnvironmentVariable("CC", "gcc.exe", "User")
-				[Environment]::SetEnvironmentVariable("CXX", "g++.exe", "User")
-				refreshenv
-
+    [Environment]::SetEnvironmentVariable("CC", "gcc.exe", "User")
+    [Environment]::SetEnvironmentVariable("CXX", "g++.exe", "User")
+    refreshenv
 
   - Temporarily (only for the current shell):
 
-			$Env:CC="clang.exe"
-			$Env:CXX="clang++.exe"
+   $Env:CC="clang.exe"
+   $Env:CXX="clang++.exe"
 
 </details>
 
@@ -86,7 +85,8 @@ CMake uses the environment variables CC and CXX to decide which compiler to use.
 
 To configure the project, you could use `cmake`, or `ccmake` or `cmake-gui`. Each of them are explained in the following:
 
-#### (2.a) Configuring via cmake:
+#### (2.a) Configuring via cmake
+
 With Cmake directly:
 
     cmake -S . -B ./build
@@ -98,7 +98,7 @@ Instead, if you have CMake version 3.21+, you can use one of the configuration p
     cmake . --preset <configure-preset>
     cmake --build
 
-#### (2.b) Configuring via ccmake:
+#### (2.b) Configuring via ccmake
 
 With the Cmake Curses Dialog Command Line tool:
 
@@ -107,14 +107,16 @@ With the Cmake Curses Dialog Command Line tool:
 Once `ccmake` has finished setting up, press 'c' to configure the project,
 press 'g' to generate, and 'q' to quit.
 
-#### (2.c) Configuring via cmake-gui:
+#### (2.c) Configuring via cmake-gui
 
 To use the GUI of the cmake:
 
 2.c.1) Open cmake-gui from the project directory:
+
 ```
 cmake-gui .
 ```
+
 2.c.2) Set the build directory:
 
 ![build_dir](https://user-images.githubusercontent.com/16418197/82524586-fa48e380-9af4-11ea-8514-4e18a063d8eb.jpg)
@@ -152,6 +154,7 @@ Choose "Visual Studio 16 2019" as the generator:
 You should have already set `C` and `CXX` to `clang.exe` and `clang++.exe`.
 
 Choose "Visual Studio 16 2019" as the generator. To tell Visual studio to use `clang-cl.exe`:
+
 - If you use the LLVM that is shipped with Visual Studio: write `ClangCl` under "optional toolset to use".
 
 <img src="https://user-images.githubusercontent.com/16418197/82781142-ae60ac00-9e1e-11ea-8c77-222b005a8f7e.png" alt="visual_studio">
@@ -169,6 +172,7 @@ Choose "Visual Studio 16 2019" as the generator. To tell Visual studio to use `c
 ![generate](https://user-images.githubusercontent.com/16418197/82781591-c97feb80-9e1f-11ea-86c8-f2748b96f516.png)
 
 ### (3) Build the project
+
 Once you have selected all the options you would like to use, you can build the
 project (all targets):
 
@@ -177,7 +181,6 @@ project (all targets):
 For Visual Studio, give the build configuration (Release, RelWithDeb, Debug, etc) like the following:
 
     cmake --build ./build -- /p:configuration=Release
-
 
 ### Running the tests
 
@@ -188,5 +191,3 @@ cd ./build
 ctest -C Debug
 cd ../
 ```
-
-

--- a/README_dependencies.md
+++ b/README_dependencies.md
@@ -1,16 +1,17 @@
 ## Dependencies
 
 Note about install commands:
+
 - for Windows, we use [choco](https://chocolatey.org/install).
 - for macOS, we use [brew](https://brew.sh/).
 - In case of an error in cmake, make sure that the dependencies are on the PATH.
-
 
 ### Too Long, Didn't Install
 
 This is a really long list of dependencies, and it's easy to mess up. That's why:
 
 #### Docker
+
 We have a Docker image that's already set up for you. See the [Docker instructions](./README_docker.md).
 
 #### Setup-cpp
@@ -20,6 +21,7 @@ We have [setup-cpp](https://github.com/aminya/setup-cpp) that is a cross-platfor
 Please check [the setup-cpp documentation](https://github.com/aminya/setup-cpp) for more information.
 
 For example, on Windows, you can run the following to install llvm, cmake, ninja, ccache, and cppcheck.
+
 ```ps1
 # windows example (open shell as admin)
 curl -LJO "https://github.com/aminya/setup-cpp/releases/download/v0.5.7/setup_cpp_windows.exe"
@@ -29,164 +31,163 @@ RefreshEnv.cmd # reload the environment
 ```
 
 ### Necessary Dependencies
+
 1. A C++ compiler that supports C++17.
 See [cppreference.com](https://en.cppreference.com/w/cpp/compiler_support)
 to see which features are supported by each compiler.
 The following compilers should work:
 
-  * [gcc 7+](https://gcc.gnu.org/)
-	<details>
-	<summary>Install command</summary>
+- [gcc 7+](https://gcc.gnu.org/)
+ <details>
+ <summary>Install command</summary>
 
-	- Debian/Ubuntu:
+ 	- Debian/Ubuntu:
 
-			sudo apt install build-essential
+   sudo apt install build-essential
 
-	- Windows:
+ 	- Windows:
 
-			choco install mingw -y
+   choco install mingw -y
 
-	- MacOS:
+ 	- MacOS:
 
-			brew install gcc
-	</details>
+   brew install gcc
+ </details>
 
-  * [clang 6+](https://clang.llvm.org/)
-	<details>
-	<summary>Install command</summary>
+- [clang 6+](https://clang.llvm.org/)
+ <details>
+ <summary>Install command</summary>
 
-	- Debian/Ubuntu:
+ 	- Debian/Ubuntu:
 
-			bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+   bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
-	- Windows:
+ 	- Windows:
 
-		Visual Studio 2019 ships with LLVM (see the Visual Studio section). However, to install LLVM separately:
+  Visual Studio 2019 ships with LLVM (see the Visual Studio section). However, to install LLVM separately:
 
-			choco install llvm -y
+   choco install llvm -y
 
-		llvm-utils for using external LLVM with Visual Studio generator:
+  llvm-utils for using external LLVM with Visual Studio generator:
 
-			git clone https://github.com/zufuliu/llvm-utils.git
-			cd llvm-utils/VS2017
-			.\install.bat
+   git clone https://github.com/zufuliu/llvm-utils.git
+   cd llvm-utils/VS2017
+   .\install.bat
 
-	- MacOS:
+ 	- MacOS:
 
-			brew install llvm
-	</details>
+   brew install llvm
+ </details>
 
-  * [Visual Studio 2019 or higher](https://visualstudio.microsoft.com/)
-	<details>
-	<summary>Install command + Environment setup</summary>
+- [Visual Studio 2019 or higher](https://visualstudio.microsoft.com/)
+ <details>
+ <summary>Install command + Environment setup</summary>
 
-	On Windows, you need to install Visual Studio 2019 because of the SDK and libraries that ship with it.
+ On Windows, you need to install Visual Studio 2019 because of the SDK and libraries that ship with it.
 
-  	Visual Studio IDE - 2019 Community (installs Clang too):
+   Visual Studio IDE - 2019 Community (installs Clang too):
 
-  	  	choco install -y visualstudio2019community --package-parameters "add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --passive --locale en-US"
+      choco install -y visualstudio2019community --package-parameters "add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional --passive --locale en-US"
 
-	Put MSVC compiler, Clang compiler, and vcvarsall.bat on the path:
+ Put MSVC compiler, Clang compiler, and vcvarsall.bat on the path:
 
-			choco install vswhere -y
-			refreshenv
+   choco install vswhere -y
+   refreshenv
 
-			# change to x86 for 32bit
-			$clpath = vswhere -products * -latest -prerelease -find **/Hostx64/x64/*
-			$clangpath = vswhere -products * -latest -prerelease -find **/Llvm/bin/*
-			$vcvarsallpath =  vswhere -products * -latest -prerelease -find **/Auxiliary/Build/*
+   # change to x86 for 32bit
+   $clpath = vswhere -products * -latest -prerelease -find **/Hostx64/x64/*
+   $clangpath = vswhere -products * -latest -prerelease -find **/Llvm/bin/*
+   $vcvarsallpath =  vswhere -products * -latest -prerelease -find **/Auxiliary/Build/*
 
-			$path = [System.Environment]::GetEnvironmentVariable("PATH", "User")
-			[Environment]::SetEnvironmentVariable("Path", $path + ";$clpath" + ";$clangpath" + ";$vcvarsallpath", "User")
-			refreshenv
+   $path = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+   [Environment]::SetEnvironmentVariable("Path", $path + ";$clpath" + ";$clangpath" + ";$vcvarsallpath", "User")
+   refreshenv
 
-	</details>
-
+ </details>
 
 2. [CMake 3.21+](https://cmake.org/)
-	<details>
-	<summary>Install Command</summary>
+ <details>
+ <summary>Install Command</summary>
 
-	- Debian/Ubuntu:
+ - Debian/Ubuntu:
 
-			sudo apt-get install cmake
+   sudo apt-get install cmake
 
-	- Windows:
+ - Windows:
 
-			choco install cmake -y
+   choco install cmake -y
 
-	- MacOS:
+ - MacOS:
 
-			brew install cmake
+   brew install cmake
 
-	</details>
+ </details>
 
 ### Optional Dependencies
+
 #### C++ Tools
-  * [Doxygen](http://doxygen.nl/)
-	<details>
-	<summary>Install Command</summary>
 
-	- Debian/Ubuntu:
+- [Doxygen](http://doxygen.nl/)
+ <details>
+ <summary>Install Command</summary>
 
-			sudo apt-get install doxygen
-			sudo apt-get install graphviz
+ 	- Debian/Ubuntu:
 
-	- Windows:
+   sudo apt-get install doxygen
+   sudo apt-get install graphviz
 
-			choco install doxygen.install -y
-			choco install graphviz -y
+ 	- Windows:
 
-	- MacOS:
+   choco install doxygen.install -y
+   choco install graphviz -y
 
-			brew install doxygen
-	 		brew install graphviz
+ 	- MacOS:
 
-	</details>
+   brew install doxygen
+    brew install graphviz
 
+ </details>
 
-  * [ccache](https://ccache.dev/)
-	<details>
-	<summary>Install Command</summary>
+- [ccache](https://ccache.dev/)
+ <details>
+ <summary>Install Command</summary>
 
-	- Debian/Ubuntu:
+ 	- Debian/Ubuntu:
 
-			sudo apt-get install ccache
+   sudo apt-get install ccache
 
-	- Windows:
+ 	- Windows:
 
-			choco install ccache -y
+   choco install ccache -y
 
-	- MacOS:
+ 	- MacOS:
 
-			brew install ccache
+   brew install ccache
 
-	</details>
+ </details>
 
+- [Cppcheck](http://cppcheck.sourceforge.net/)
+ <details>
+ <summary>Install Command</summary>
 
-  * [Cppcheck](http://cppcheck.sourceforge.net/)
-	<details>
-	<summary>Install Command</summary>
+ 	- Debian/Ubuntu:
 
-	- Debian/Ubuntu:
+   sudo apt-get install cppcheck
 
-			sudo apt-get install cppcheck
+ 	- Windows:
 
-	- Windows:
+   choco install cppcheck -y
 
-			choco install cppcheck -y
+ 	- MacOS:
 
-	- MacOS:
+   brew install cppcheck
 
-			brew install cppcheck
+ </details>
 
-	</details>
+- [include-what-you-use](https://include-what-you-use.org/)
+ <details>
+ <summary>Install Command</summary>
 
-
-  * [include-what-you-use](https://include-what-you-use.org/)
-	<details>
-	<summary>Install Command</summary>
-
-	Follow instructions here:
-	https://github.com/include-what-you-use/include-what-you-use#how-to-install
-	</details>
+ Follow instructions here:
+ <https://github.com/include-what-you-use/include-what-you-use#how-to-install>
+ </details>

--- a/README_docker.md
+++ b/README_docker.md
@@ -10,4 +10,3 @@ docker compose run -it --rm --build ubuntu
 
 This command will put you in a `bash` session in a Ubuntu 24.04 Docker container,
 with all of the tools listed in the [Dependencies](#dependencies) section already installed.
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,10 @@
-add_subdirectory(sample_library)
 add_subdirectory(ftxui_sample)
+add_subdirectory(sample_library)
+
+# add_subdirectory(adapter)
+add_subdirectory(buffer)
+# add_subdirectory(dlt_parser)
+add_subdirectory(options)
+
+# add_executable(main main.cpp)
+# target_link_libraries(main PRIVATE dlt_parser adapter options)

--- a/src/adapter/CMakeLists.txt
+++ b/src/adapter/CMakeLists.txt
@@ -1,0 +1,13 @@
+if(dlt_explorer_ENABLE_DLT_DAEMON)
+  add_library(adapter with_dlt_daemon/src/adapter.cpp)
+  target_include_directories(
+    adapter
+    PUBLIC with_dlt_daemon/include)
+  target_link_libraries(adapter PUBLIC dlt)
+  target_compile_definitions(adapter PUBLIC $<$<BOOL:${ENABLE_DLT_DAEMON}>:ENABLE_DLT_DAEMON>)
+else()
+  add_library(adapter without_dlt_daemon/src/adapter.cpp)
+  target_include_directories(
+    adapter
+    PUBLIC without_dlt_daemon/include)
+endif()

--- a/src/adapter/with_dlt_daemon/include/adapter.h
+++ b/src/adapter/with_dlt_daemon/include/adapter.h
@@ -1,0 +1,39 @@
+#include <filesystem>
+
+#include "dlt_common.h"
+#include "dlt_protocol.h"
+
+extern const char *message_type[8];
+extern const char *log_info[16];
+extern const char *trace_type[16];
+extern const char *nw_trace_type[16];
+extern const char *control_type[16];
+static const char *service_id_name[21] = { "",
+  "set_log_level",
+  "set_trace_status",
+  "get_log_info",
+  "get_default_log_level",
+  "store_config",
+  "reset_to_factory_default",
+  "set_com_interface_status",
+  "set_com_interface_max_bandwidth",
+  "set_verbose_mode",
+  "set_message_filtering",
+  "set_timing_packets",
+  "get_local_time",
+  "use_ecu_id",
+  "use_session_id",
+  "use_timestamp",
+  "use_extended_header",
+  "set_default_log_level",
+  "set_default_trace_status",
+  "get_software_version",
+  "message_buffer_overflow" };
+static const char
+  *return_type[9] = { "ok", "not_supported", "error", "perm_denied", "warning", "", "", "", "no_matching_context_id" };
+
+
+/**
+ * Parse DLT file as done in dlt-daemon
+ */
+void parse_dlt_daemon(std::filesystem::path const &path);

--- a/src/adapter/with_dlt_daemon/src/adapter.cpp
+++ b/src/adapter/with_dlt_daemon/src/adapter.cpp
@@ -1,0 +1,30 @@
+#include "adapter.h"
+
+#include "dlt_common.h"
+
+#include <array>
+#include <filesystem>
+
+constexpr int DLT_DAEMON_TEXTSIZE = 10024;
+
+void parse_dlt_daemon(std::filesystem::path const &path)
+{
+  DltFile file;
+  int const verbose{ 0 };
+  static std::array<char, DLT_DAEMON_TEXTSIZE> text;
+  // static char text[DLT_DAEMON_TEXTSIZE];
+
+  /* Normal Use-Case, expected 0 */
+  dlt_log_init(0);
+  dlt_file_init(&file, 0);
+  dlt_file_open(&file, path.c_str(), 0);
+
+  while (dlt_file_read(&file, 0) >= 0) {}
+
+  for (int i = 0; i < file.counter; i++) {
+    dlt_file_message(&file, i, 0);
+    dlt_message_print_ascii(&file.msg, text.data(), DLT_DAEMON_TEXTSIZE, verbose);
+  }
+
+  dlt_file_free(&file, 0);
+}

--- a/src/adapter/without_dlt_daemon/include/adapter.h
+++ b/src/adapter/without_dlt_daemon/include/adapter.h
@@ -1,0 +1,6 @@
+#include <filesystem>
+
+/**
+ * Parse DLT file as done in dlt-daemon
+ */
+void parse_dlt_daemon(std::filesystem::path const &path);

--- a/src/adapter/without_dlt_daemon/src/adapter.cpp
+++ b/src/adapter/without_dlt_daemon/src/adapter.cpp
@@ -1,0 +1,11 @@
+#include "adapter.h"
+
+
+#include <filesystem>
+#include <stdexcept>
+
+
+void parse_dlt_daemon(std::filesystem::path const & /*path*/)
+{
+  throw std::runtime_error("not linked with dlt-daemon");
+}

--- a/src/buffer/CMakeLists.txt
+++ b/src/buffer/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_library(buffer src/buffer.cpp)
+add_library(dlt_explorer::buffer ALIAS buffer)
+
+include(GenerateExportHeader)
+generate_export_header(buffer)
+
+target_sources(
+  buffer
+  PRIVATE src/buffer.cpp
+  PUBLIC
+    FILE_SET HEADERS
+      FILES include/buffer.h
+    FILE_SET generated_headers
+      TYPE HEADERS
+      BASE_DIRS $<TARGET_PROPERTY:buffer,BINARY_DIR>
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/buffer_export.h
+)
+
+target_include_directories(buffer
+  PUBLIC
+    include
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(buffer
+  PUBLIC
+    fmt::fmt
+  PRIVATE
+    dlt_explorer::dlt_explorer_options
+    dlt_explorer::dlt_explorer_warnings
+)

--- a/src/buffer/include/buffer.h
+++ b/src/buffer/include/buffer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "buffer_export.h"
+
+#include <fmt/base.h>
+
+#include <string_view>
+#include <vector>
+
+struct Hex
+{
+  long value;
+};
+
+template<> struct fmt::formatter<Hex> : formatter<string_view>
+{
+  auto format(Hex hex, format_context &ctx) const { return fmt::format_to(ctx.out(), "0x{:x}", hex.value); }
+};
+
+
+struct Bin
+{
+  long value;
+};
+
+template<> struct fmt::formatter<Bin> : formatter<string_view>
+{
+  auto format(Bin binary, format_context &ctx) const { return fmt::format_to(ctx.out(), "0b{:b}", binary.value); }
+};
+
+
+class Buffer
+{
+  std::vector<char> m_buffer;
+
+public:
+  explicit BUFFER_EXPORT Buffer(size_t capacity);
+
+  [[nodiscard]] BUFFER_EXPORT size_t size() const;
+  [[nodiscard]] BUFFER_EXPORT size_t capacity() const;
+
+  std::string_view store(auto args)
+  {
+    auto old_size = m_buffer.size();
+    fmt::format_to(std::back_inserter(m_buffer), "{}", args);
+    return { m_buffer.data() + old_size, m_buffer.size() - old_size };
+  }
+};

--- a/src/buffer/src/buffer.cpp
+++ b/src/buffer/src/buffer.cpp
@@ -1,0 +1,8 @@
+#include "buffer.h"
+
+#include <cstddef>
+
+Buffer::Buffer(size_t capacity) { m_buffer.reserve(capacity); }
+
+size_t Buffer::size() const { return m_buffer.size(); }
+size_t Buffer::capacity() const { return m_buffer.capacity(); }

--- a/src/dlt_parser/CMakeLists.txt
+++ b/src/dlt_parser/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(Boost REQUIRED)
+
+add_library(dlt_parser src/dlt_parser.cpp)
+target_include_directories(
+  dlt_parser
+  PUBLIC include
+  PRIVATE ${Boost_INCLUDE_DIRS})
+
+target_link_libraries(dlt_parser PRIVATE adapter buffer)
+
+if(ENABLE_DLT_DAEMON)
+  target_link_libraries(dlt_parser PUBLIC dlt)
+endif()

--- a/src/dlt_parser/include/dlt_parser.h
+++ b/src/dlt_parser/include/dlt_parser.h
@@ -1,0 +1,3 @@
+#include <filesystem>
+
+void parse_dlt_explorer(std::filesystem::path const &path);

--- a/src/dlt_parser/src/dlt_parser.cpp
+++ b/src/dlt_parser/src/dlt_parser.cpp
@@ -1,0 +1,482 @@
+#include "dlt_parser.h"
+
+#include "adapter.h"
+#include "buffer.h"
+#include "dlt_common.h"
+
+#include <boost/interprocess/file_mapping.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+
+#include <bit>
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <span>
+#include <sstream>
+#include <syslog.h>
+#include <variant>
+#include <vector>
+
+using namespace boost::interprocess;
+
+template <typename T> void print(std::span<T> data) {
+  for (const auto &c : data) {
+    std::cout << c;
+  }
+  std::cout << '\n';
+}
+
+struct RawData {
+  std::string_view data;
+};
+
+struct Print {
+  Print(std::ostream &os, bool non_verbose)
+      : m_os{os}, m_nonverbose{non_verbose} {}
+
+  void operator()(std::string_view payload) const {
+    m_os << "string_view: [";
+    if (m_nonverbose) {
+      m_os << std::setfill('0') << std::hex;
+      for (auto i : payload) {
+        m_os << std::setw(2) << static_cast<int>(i) << ' ';
+      }
+      m_os << std::setfill(' ') << std::dec;
+    } else {
+      m_os << payload;
+    }
+    m_os << "]";
+  }
+
+  void operator()(RawData payload) const {
+    m_os << " RawData: [" << std::setfill('0') << std::hex;
+    for (auto i : payload.data) {
+      m_os << std::setw(2) << static_cast<int>(i) << ' ';
+    }
+    m_os << std::setfill(' ') << std::dec << "]";
+  }
+
+  void operator()(auto payload) const {
+    m_os << typeid(payload).name() << " auto: [" << payload << "]";
+  }
+
+  std::ostream &m_os;
+  bool m_nonverbose;
+};
+
+class DLT {
+  using payload_t = std::variant<std::string_view, RawData, bool, int8_t,
+                                 uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+                                 int64_t, uint64_t, float32_t, float64_t>;
+
+  static_assert(sizeof(payload_t) == 24);
+  static_assert(alignof(payload_t) == 8);
+
+  std::vector<std::string_view> m_patterns;
+  std::vector<uint32_t> m_seconds;
+  std::vector<int32_t> m_microseconds;
+  std::vector<std::string_view> m_ecus;
+  std::vector<uint8_t> m_htyps;
+  std::vector<uint8_t> m_mcnts;
+  std::vector<uint16_t> m_lens;
+  std::vector<uint32_t> m_seids;
+  std::vector<uint32_t> m_tmsps;
+  std::vector<uint8_t> m_msins;
+  std::vector<uint8_t> m_noars;
+  std::vector<std::string_view> m_apids;
+  std::vector<std::string_view> m_ctids;
+  std::vector<std::string_view> m_service_id_names;
+  std::vector<std::string_view> m_return_types;
+  // The size of a variant is the size of the largest type it can hold, plus
+  // the alignment requirement of the type with the biggest aligmnent because it
+  // needs something to know what is the active alternative. In this case it is
+  // sizeof(string_view) + alignment = 16 + 8 = 24.
+  // std::vector<payload_t> m_payloads;
+  std::vector<std::string_view> m_payloads;
+
+  Buffer m_buffer;
+
+  // invariant: sizes of all vectors must be the same
+  size_t m_size;
+  mapped_region m_region;
+
+public:
+  DLT() = delete;
+  DLT(mapped_region region)
+      : m_region(std::move(region)), m_size(0), m_buffer(1024) {
+    assert(m_buffer.capacity() == 1024);
+
+    uint8_t const *const begin = static_cast<uint8_t *>(m_region.get_address());
+    uint8_t const *const end = begin + m_region.get_size();
+    auto buffer = m_region.get_address();
+
+    while (static_cast<uint8_t *>(buffer) < end) {
+      // Storage header
+      auto const storageHeader = static_cast<DltStorageHeader *>(buffer);
+      buffer = static_cast<uint8_t *>(buffer) + sizeof(DltStorageHeader);
+      m_patterns.emplace_back(
+          std::string_view{storageHeader->pattern, DLT_ID_SIZE});
+      auto const s = storageHeader->seconds;
+      m_seconds.emplace_back(s);
+      auto const ms = storageHeader->microseconds;
+      m_microseconds.emplace_back(ms);
+      m_ecus.emplace_back(std::string_view{storageHeader->ecu, DLT_ID_SIZE});
+
+      if (dlt_check_storageheader(storageHeader) != DLT_RETURN_TRUE) {
+        throw std::runtime_error("Invalid DLT storage header");
+      }
+
+      // Standard header
+      auto const standardHeader = static_cast<DltStandardHeader *>(buffer);
+      buffer = static_cast<uint8_t *>(buffer) + sizeof(DltStandardHeader);
+      auto const htyp = standardHeader->htyp;
+      m_htyps.emplace_back(htyp);
+      auto const mcnt = standardHeader->mcnt;
+      m_mcnts.emplace_back(mcnt);
+      auto const len = standardHeader->len;
+      m_lens.emplace_back(len);
+
+      /* load standard header extra parameters if used */
+      if (DLT_STANDARD_HEADER_EXTRA_SIZE(htyp)) {
+        if (DLT_IS_HTYP_WEID(htyp)) {
+          m_ecus.back() = std::string_view(static_cast<char *>(buffer),
+                                           static_cast<size_t>(DLT_ID_SIZE));
+          buffer = static_cast<uint8_t *>(buffer) + DLT_ID_SIZE;
+        }
+
+        if (DLT_IS_HTYP_WSID(htyp)) {
+          m_seids.emplace_back(DLT_BETOH_32(*static_cast<uint32_t *>(buffer)));
+          buffer = static_cast<uint8_t *>(buffer) + DLT_SIZE_WSID;
+        } else {
+          m_seids.emplace_back(0);
+        }
+
+        if (DLT_IS_HTYP_WTMS(htyp)) {
+          m_tmsps.emplace_back(DLT_BETOH_32(*static_cast<uint32_t *>(buffer)));
+          buffer = static_cast<uint8_t *>(buffer) + DLT_SIZE_WTMS;
+        } else {
+          m_tmsps.emplace_back(0);
+        }
+      } else {
+        m_seids.emplace_back(0);
+        m_tmsps.emplace_back(0);
+      }
+
+      /* set extended header ptr */
+      uint8_t msin = 0;
+      uint8_t noar = 0;
+      std::string_view apid = "";
+      std::string_view ctid = "";
+      if (DLT_IS_HTYP_UEH(htyp)) {
+        auto const extendedHeader = static_cast<DltExtendedHeader *>(buffer);
+        msin = extendedHeader->msin;
+        noar = extendedHeader->noar;
+        apid = std::string_view{extendedHeader->apid, DLT_ID_SIZE};
+        ctid = std::string_view{extendedHeader->ctid, DLT_ID_SIZE};
+        buffer = static_cast<uint8_t *>(buffer) + sizeof(DltExtendedHeader);
+      }
+      m_msins.emplace_back(msin);
+      m_noars.emplace_back(noar);
+      m_apids.emplace_back(apid);
+      m_ctids.emplace_back(ctid);
+
+      // Payload
+      /* calculate complete size of headers */
+      auto const headerSize =
+          (uint32_t)(sizeof(DltStorageHeader) + sizeof(DltStandardHeader) +
+                     DLT_STANDARD_HEADER_EXTRA_SIZE(htyp) +
+                     (DLT_IS_HTYP_UEH(htyp) ? sizeof(DltExtendedHeader) : 0));
+
+      /* calculate complete size of payload */
+      int32_t const dataSize = DLT_BETOH_16(len) +
+                               (int32_t)sizeof(DltStorageHeader) -
+                               static_cast<int32_t>(headerSize);
+
+      std::string_view payload{static_cast<char *>(buffer),
+                               static_cast<size_t>(dataSize)};
+      std::string_view service_name_id = "";
+      std::string_view return_type_name = "";
+      // non-verbose mode the payload buffer can be:
+      // | service id name | return type | payload |
+      if (DLT_IS_HTYP_UEH(htyp) && _dlt_msg_is_nonverbose(htyp, msin)) {
+        // determine service id name
+        auto id_tmp = _dlt_msg_read_value<uint32_t>(payload);
+        auto id = DLT_ENDIAN_GET_32(htyp, id_tmp);
+        if (_dlt_msg_is_control(htyp, msin) && id < DLT_SERVICE_ID_LAST_ENTRY) {
+          // Possible out of bounds if id > service_id_name.size()
+          // The check is ignored in favor of  performance
+          service_name_id = service_id_name[id];
+        }
+
+        // determine return type name
+        if (_dlt_msg_is_control_response(htyp, msin)) {
+          auto retval = _dlt_msg_read_value<uint8_t>(payload);
+          // Possible out of bounds if id > service_id_name.size()
+          // The check is ignored in favor of  performance
+          return_type_name = return_type[retval];
+        }
+        // payload = payload;
+        payload = m_buffer.store(service_id_name + payload);
+      } else {
+        /* At this point, it is ensured that a extended header is available */
+
+        // verbose mode the payload buffer can be:
+        // | type info | payload |
+        for (size_t n = 0; n < noar; ++n) {
+          auto type_info_tmp = _dlt_msg_read_value<uint32_t>(payload);
+          uint32_t type_info = DLT_ENDIAN_GET_32(htyp, type_info_tmp);
+
+          if ((type_info & DLT_TYPE_INFO_STRG) &&
+              (((type_info & DLT_TYPE_INFO_SCOD) == DLT_SCOD_ASCII) ||
+               ((type_info & DLT_TYPE_INFO_SCOD) == DLT_SCOD_UTF8))) {
+
+            auto value = _dlt_msg_read_value<uint16_t>(payload);
+            payload = payload;
+
+          } else if (type_info & DLT_TYPE_INFO_BOOL) {
+
+            if (type_info & DLT_TYPE_INFO_VARI) {
+              throw std::runtime_error("Not implemented yet");
+            }
+
+            auto value = _dlt_msg_read_value<bool>(payload);
+            payload = value ? "true" : "false";
+
+          } else if ((type_info & DLT_TYPE_INFO_SINT) ||
+                     (type_info & DLT_TYPE_INFO_UINT)) {
+
+            if (type_info & DLT_TYPE_INFO_VARI) {
+              throw std::runtime_error("Not implemented yet");
+            }
+
+            if (type_info & DLT_TYPE_INFO_FIXP) {
+              throw std::runtime_error("Not implemented yet");
+            }
+
+            switch (type_info & DLT_TYPE_INFO_TYLE) {
+            case DLT_TYLE_8BIT: {
+              auto value = _dlt_msg_read_value<uint8_t>(payload);
+              // payload = static_cast<int64_t>(value);
+              payload = m_buffer.store(value);
+              break;
+            }
+            case DLT_TYLE_16BIT: {
+              auto value_tmp = _dlt_msg_read_value<uint16_t>(payload);
+              // payload = DLT_ENDIAN_GET_16(htyp, value_tmp);
+              payload = m_buffer.store(DLT_ENDIAN_GET_16(htyp, value_tmp));
+              break;
+            }
+            case DLT_TYLE_32BIT: {
+              auto value_tmp = _dlt_msg_read_value<uint32_t>(payload);
+              // payload = DLT_ENDIAN_GET_32(htyp, value_tmp);
+              payload = m_buffer.store(DLT_ENDIAN_GET_32(htyp, value_tmp));
+              break;
+            }
+            case DLT_TYLE_64BIT: {
+              auto value_tmp = _dlt_msg_read_value<uint64_t>(payload);
+              // payload = DLT_ENDIAN_GET_64(htyp, value_tmp);
+              payload = m_buffer.store(DLT_ENDIAN_GET_64(htyp, value_tmp));
+              break;
+            }
+            case DLT_TYLE_128BIT: {
+              throw std::runtime_error("Not implemented yet");
+              break;
+            }
+            default: {
+              throw std::runtime_error("Unknown type info in DLT message");
+            }
+            }
+
+          } else if (type_info & DLT_TYPE_INFO_FLOA) {
+            if (type_info & DLT_TYPE_INFO_VARI) {
+              throw std::runtime_error("Not implemented yet");
+            }
+
+            switch (type_info & DLT_TYPE_INFO_TYLE) {
+            case DLT_TYLE_8BIT: {
+              auto value = _dlt_msg_read_value<uint8_t>(payload);
+              // payload = static_cast<int64_t>(value);
+              payload = m_buffer.store(value);
+              break;
+            }
+            case DLT_TYLE_16BIT: {
+              auto value_tmp = _dlt_msg_read_value<float>(payload);
+              // payload = DLT_ENDIAN_GET_16(htyp, value_tmp);
+              // payload = m_buffer.store(DLT_ENDIAN_GET_16(htyp, value_tmp));
+              break;
+            }
+            case DLT_TYLE_32BIT: {
+              auto value = _dlt_msg_read_value<float32_t>(payload);
+              auto value_int32 = std::bit_cast<int32_t>(value);
+              auto value_int32_swap = DLT_ENDIAN_GET_32(htyp, value_int32);
+              auto value_corrected = std::bit_cast<float32_t>(value_int32_swap);
+              // payload = value_corrected;
+              payload = m_buffer.store(value_corrected);
+              break;
+            }
+            case DLT_TYLE_64BIT: {
+              auto value = _dlt_msg_read_value<float64_t>(payload);
+              auto value_int64 = std::bit_cast<int64_t>(value);
+              auto value_int64_swap = DLT_ENDIAN_GET_64(htyp, value_int64);
+              auto value_corrected = std::bit_cast<float64_t>(value_int64_swap);
+              // payload = value_corrected;
+              payload = m_buffer.store(value_corrected);
+              break;
+            }
+            case DLT_TYLE_128BIT: {
+              throw std::runtime_error("Not implemented yet");
+              break;
+            }
+            default: {
+              throw std::runtime_error("Unknown type info in DLT message");
+            }
+            }
+          } else if (type_info & DLT_TYPE_INFO_RAWD) {
+            auto value = _dlt_msg_read_value<uint16_t>(payload);
+            // payload = RawData{payload};
+            payload = m_buffer.store(value);
+          }
+        }
+      }
+      m_service_id_names.emplace_back(service_name_id);
+      m_return_types.emplace_back(return_type_name);
+      m_payloads.emplace_back(payload);
+
+      buffer = static_cast<uint8_t *>(buffer) + dataSize;
+
+      m_size++;
+    }
+
+    assert(m_patterns.size() == m_size);
+    assert(m_seconds.size() == m_size);
+    assert(m_microseconds.size() == m_size);
+    assert(m_ecus.size() == m_size);
+    assert(m_htyps.size() == m_size);
+    assert(m_mcnts.size() == m_size);
+    assert(m_lens.size() == m_size);
+    assert(m_seids.size() == m_size);
+    assert(m_tmsps.size() == m_size);
+    assert(m_msins.size() == m_size);
+    assert(m_noars.size() == m_size);
+    assert(m_apids.size() == m_size);
+    assert(m_ctids.size() == m_size);
+    assert(m_service_id_names.size() == m_size);
+    assert(m_return_types.size() == m_size);
+    assert(m_payloads.size() == m_size);
+  }
+
+  void print() {
+    std::ostringstream os;
+    for (size_t i = 0; i < m_size; ++i) {
+      auto mt =
+          message_type[DLT_GET_MSIN_MSTP(static_cast<int>(m_msins.at(i)))];
+      auto id = DLT_GET_MSIN_MTIN(static_cast<int>(m_msins.at(i)));
+      auto li = log_info[id];
+      auto tt = trace_type[id];
+      auto ntt = nw_trace_type[id];
+      auto ct = control_type[id];
+
+      // os << "Pattern: " << dlt.m_patterns.at(i) << ", ";
+      os << "Seconds: " << m_seconds.at(i) << ", ";
+      os << "Microseconds: " << m_microseconds.at(i) << ", ";
+      os << "ECU: " << m_ecus.at(i) << ", ";
+      os << "HTYP: " << static_cast<int>(m_htyps.at(i)) << ", ";
+      os << "MCNT: " << static_cast<int>(m_mcnts.at(i)) << ", ";
+      os << "Length: " << m_lens.at(i) << " " << DLT_BETOH_16(m_lens.at(i))
+         << ", ";
+      os << "SEID: " << m_seids.at(i) << ", ";
+      os << "TMSP: " << m_tmsps.at(i) << ", ";
+      os << "MSIN: (" << mt << ", " << li << ", " << tt << ", " << ntt << ", "
+         << ct << "), ";
+      os << "NOAR: " << static_cast<int>(m_noars.at(i)) << ", ";
+      os << "APID: " << m_apids.at(i) << ", ";
+      os << "CTID: " << m_ctids.at(i) << ", ";
+      // os << '\n';
+      os << "Payload: ";
+      os << m_service_id_names.at(i) << ", ";
+      os << m_return_types.at(i) << ", ";
+      os << m_payloads.at(i) << ", ";
+      // std::visit(
+      //     Print{os, _dlt_msg_is_nonverbose(m_htyps.at(i), m_msins.at(i))},
+      //     m_payloads.at(i));
+      os << '\n';
+    }
+    std::cout << os.str();
+  }
+
+  friend std::ostream &operator<<(std::ostream &os, DLT const &dlt) {
+    os << std::boolalpha;
+    for (size_t i = 0; i < dlt.m_size; ++i) {
+      auto id = DLT_GET_MSIN_MSTP(static_cast<int>(dlt.m_msins.at(i)));
+      auto mt = message_type[id];
+      auto li = log_info[id];
+      auto tt = trace_type[id];
+      auto ntt = nw_trace_type[id];
+      auto ct = control_type[id];
+
+      auto time = std::chrono::seconds{dlt.m_seconds.at(i)} +
+                  std::chrono::microseconds{dlt.m_microseconds.at(i)};
+      std::chrono::system_clock::time_point tp{time};
+      os << tp << "|";
+      os << std::setw(10) << dlt.m_tmsps.at(i) << "|";
+      os << std::setw(6) << static_cast<int>(dlt.m_mcnts.at(i)) << "|";
+      os << std::setw(4) << dlt.m_ecus.at(i) << "|";
+      os << std::setw(4) << dlt.m_apids.at(i) << "|";
+      os << std::setw(4) << dlt.m_ctids.at(i) << "|";
+      os << std::setw(10)
+         << message_type[DLT_GET_MSIN_MSTP(static_cast<int>(dlt.m_msins.at(i)))]
+         << "|";
+      os << std::setw(10)
+         << log_info[DLT_GET_MSIN_MTIN(static_cast<int>(dlt.m_msins.at(i)))]
+         << "|";
+      if (dlt._dlt_msg_is_nonverbose(dlt.m_htyps.at(i), dlt.m_msins.at(i))) {
+        os << "N";
+      } else {
+        os << "V";
+      }
+      os << dlt.m_noars.at(i) << "|";
+      os << dlt.m_payloads.at(i) << "|";
+      // std::visit(Print{os, dlt._dlt_msg_is_nonverbose(dlt.m_htyps.at(i),
+      //                                                 dlt.m_msins.at(i))},
+      //            dlt.m_payloads.at(i));
+      os << '\n';
+    }
+    return os;
+  }
+
+private:
+  bool _dlt_msg_is_nonverbose(int htyp, int msin) const {
+    return (!DLT_IS_HTYP_UEH(htyp) ||
+            (DLT_IS_HTYP_UEH(htyp) && !DLT_IS_MSIN_VERB(msin)));
+  }
+
+  bool _dlt_msg_is_control(int htyp, int msin) const {
+    return DLT_IS_HTYP_UEH(htyp) &&
+           (DLT_GET_MSIN_MSTP(msin) == DLT_TYPE_CONTROL);
+  }
+
+  bool _dlt_msg_is_control_response(int htyp, int msin) const {
+    return DLT_IS_HTYP_UEH(htyp) &&
+           (DLT_GET_MSIN_MSTP(msin) == DLT_TYPE_CONTROL) &&
+           (DLT_GET_MSIN_MTIN(msin) == DLT_CONTROL_RESPONSE);
+  }
+
+  template <typename T> T _dlt_msg_read_value(std::string_view &payload) {
+    if (payload.size() < sizeof(T)) {
+      throw std::runtime_error("Payload size is less than expected");
+    }
+    auto dst = *reinterpret_cast<T *>(const_cast<char *>(payload.data()));
+    payload.remove_prefix(sizeof(T));
+    return dst;
+  }
+};
+
+void parse_dlt_explorer(std::filesystem::path const &path) {
+  file_mapping m_file(path.c_str(), read_only);
+
+  mapped_region region(m_file, read_only);
+
+  DLT dlt{std::move(region)};
+  std::cout << dlt << '\n';
+  // dlt.print();
+}

--- a/src/ftxui_sample/CMakeLists.txt
+++ b/src/ftxui_sample/CMakeLists.txt
@@ -1,19 +1,16 @@
 add_executable(intro main.cpp)
 
-target_link_libraries(
-  intro
-  PRIVATE dlt_explorer::dlt_explorer_options
-          dlt_explorer::dlt_explorer_warnings)
+target_link_libraries(intro PRIVATE dlt_explorer::dlt_explorer_options dlt_explorer::dlt_explorer_warnings)
 
 target_link_system_libraries(
   intro
   PRIVATE
-          CLI11::CLI11
-          fmt::fmt
-          spdlog::spdlog
-          lefticus::tools
-          ftxui::screen
-          ftxui::dom
-          ftxui::component)
+  CLI11::CLI11
+  fmt::fmt
+  spdlog::spdlog
+  lefticus::tools
+  ftxui::screen
+  ftxui::dom
+  ftxui::component)
 
 target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,13 @@
+#include "adapter.h"
+#include "dlt_parser.h"
+#include "options.h"
+
+int main(int argc, char *argv[]) {
+  auto options = parse_cmd_options(argc, argv);
+
+  if (options.v1) {
+    parse_dlt_daemon(options.dlt_path);
+  } else {
+    parse_dlt_explorer(options.dlt_path);
+  }
+}

--- a/src/options/CMakeLists.txt
+++ b/src/options/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(Boost REQUIRED COMPONENTS program_options)
+
+add_library(options src/options.cpp)
+target_include_directories(options PUBLIC include)
+target_link_libraries(options PRIVATE Boost::program_options)

--- a/src/options/include/options.h
+++ b/src/options/include/options.h
@@ -1,0 +1,9 @@
+#include <filesystem>
+
+struct Options {
+  std::filesystem::path dlt_path;
+  std::filesystem::path dlt_filter;
+  bool v1;
+};
+
+Options parse_cmd_options(int argc, char *argv[]);

--- a/src/options/src/options.cpp
+++ b/src/options/src/options.cpp
@@ -1,0 +1,35 @@
+#include "options.h"
+
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
+
+#include <filesystem>
+#include <iostream>
+
+namespace po = boost::program_options;
+
+Options parse_cmd_options(int argc, char **argv)
+{
+  std::filesystem::path path;
+  std::filesystem::path filter;
+  bool version1{ false };
+
+  po::options_description desc("Allowed options");
+  desc.add_options()("help", "Produce help message");
+  desc.add_options()("path", po::value<std::filesystem::path>(&path), "Path to DLT file");
+  desc.add_options()("filter", po::value<std::filesystem::path>(&filter), "Path to DLT Filter file");
+  desc.add_options()("v1", po::bool_switch(&version1), "Enable DLT v1 support");
+
+  po::variables_map var_map;
+  po::store(po::parse_command_line(argc, argv, desc), var_map);
+  po::notify(var_map);
+
+  if (var_map.contains("help")) {
+    std::cout << desc << "\n";
+    return {};
+  }
+
+  return Options{ .dlt_path = path, .dlt_filter = filter, .v1 = version1 };
+}

--- a/src/sample_library/CMakeLists.txt
+++ b/src/sample_library/CMakeLists.txt
@@ -1,9 +1,6 @@
 include(GenerateExportHeader)
 
-
 add_library(sample_library sample_library.cpp)
-
-
 
 add_library(dlt_explorer::sample_library ALIAS sample_library)
 
@@ -20,7 +17,8 @@ set_target_properties(
              CXX_VISIBILITY_PRESET hidden
              VISIBILITY_INLINES_HIDDEN YES)
 
-generate_export_header(sample_library EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/dlt_explorer/sample_library_export.hpp)
+generate_export_header(sample_library EXPORT_FILE_NAME
+                       ${PROJECT_BINARY_DIR}/include/dlt_explorer/sample_library_export.hpp)
 
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(sample_library PUBLIC SAMPLE_LIBRARY_STATIC_DEFINE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,12 +29,13 @@ add_test(NAME cli.has_help COMMAND intro --help)
 add_test(NAME cli.version_matches COMMAND intro --version)
 set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
 
-add_executable(tests tests.cpp)
+add_executable(tests buffer/test_buffer.cpp)
 target_link_libraries(
   tests
   PRIVATE dlt_explorer::dlt_explorer_warnings
           dlt_explorer::dlt_explorer_options
           dlt_explorer::sample_library
+          dlt_explorer::buffer
           Catch2::Catch2WithMain)
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/test/buffer/test_buffer.cpp
+++ b/test/buffer/test_buffer.cpp
@@ -1,0 +1,186 @@
+#include "buffer.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+
+// struct TestType{
+//   TestType(){}
+// };
+
+SCENARIO("Buffer constructor")
+{
+  GIVEN("A capacity of 1")
+  {
+    size_t const capacity{ 1 };
+
+    WHEN("constuctor is called")
+    {
+      Buffer const buffer{ capacity };
+
+      THEN("size and capacity change")
+      {
+        REQUIRE(buffer.size() == 0);
+        REQUIRE(buffer.capacity() == 1);
+      }
+    }
+  }
+
+  GIVEN("A capacity of 64")
+  {
+    size_t const capacity{ 64 };
+
+    WHEN("constuctor is called")
+    {
+      Buffer const buffer{ capacity };
+
+      THEN("size and capacity change")
+      {
+        REQUIRE(buffer.size() == 0);
+        REQUIRE(buffer.capacity() == 64);
+      }
+    }
+  }
+}
+
+SCENARIO("Buffer can store data.")
+{
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the integer 12345 is stored")
+    {
+      int const value = 12345;
+      auto result = buffer.store(value);
+
+      THEN("characters '12345' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "12345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the unsigned integer 12345 is stored")
+    {
+      unsigned int const value = 12345;
+      auto result = buffer.store(value);
+
+      THEN("characters '12345' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "12345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the float 1.2345 is stored")
+    {
+      float const value = 1.2345F;
+      auto result = buffer.store(value);
+
+      THEN("characters '1.2345' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "1.2345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the double 1.2345 is stored")
+    {
+      double const value = 1.2345;
+      auto result = buffer.store(value);
+
+      THEN("characters '1.2345' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "1.2345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the hexadecimal 0x1a2b is stored")
+    {
+      int const value = 0x1a2b;
+      auto result = buffer.store(Hex(value));
+
+      THEN("characters '0x1a2b' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "0x1a2b");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space")
+  {
+    size_t const capacity = 1024;
+    Buffer buffer{ capacity };
+
+    WHEN("the binary 0b0101 is stored")
+    {
+      int const value = 0b0101;
+      auto result = buffer.store(Bin(value));
+
+      THEN("characters '0b101' are stored in Buffer")
+      {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "0b101");
+      }
+    }
+  }
+}
+
+// SCENARIO("Buffer can store multiple data.")
+// {
+
+//   GIVEN("A Buffer with big enough space")
+//   {
+//     size_t const capacity = 1024;
+//     Buffer buffer{ capacity };
+
+//     WHEN("the integers 123 and 456 are stored")
+//     {
+//       int const value1 = 123;
+//       int const value2 = 456;
+//       auto result = buffer.store(value1, value2);
+
+//       THEN("characters '123 456' are stored in Buffer")
+//       {
+//         REQUIRE(buffer.size() == 5);
+//         REQUIRE(buffer.capacity() == 1024);
+//         REQUIRE(result == "123 456");
+//       }
+//     }
+//   }
+// }

--- a/test/dlt_parser/test_dlt_parser.cpp
+++ b/test/dlt_parser/test_dlt_parser.cpp
@@ -1,0 +1,10 @@
+#include "dlt_parser.h"
+
+#include <gtest/gtest.h>
+
+TEST(DltParser, Constructor) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}


### PR DESCRIPTION
Format README files and update .gitignore.

Refactor Buffer class to use fmt and its tests to use Catch2 and add buffer generate export header.

Add dlt-daemon option and dependency package.

Refactor adapter module. Separate with and without dlt-daemon dependency.