### PR TITLE
refactor tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,22 +20,25 @@ endif()
 include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
 # Provide a simple smoke test to make sure that the CLI works and can display a --help message
-add_test(NAME cli.has_help COMMAND intro --help)
+# add_test(NAME cli.has_help COMMAND intro --help)
 
 # Provide a test to verify that the version being reported from the application
 # matches the version given to CMake. This will be important once you package
 # your program. Real world shows that this is the kind of simple mistake that is easy
 # to make, but also easy to test for.
-add_test(NAME cli.version_matches COMMAND intro --version)
-set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
+# add_test(NAME cli.version_matches COMMAND intro --version)
+# set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
 
-add_executable(tests buffer/test_buffer.cpp)
+add_executable(tests
+  unittests/test_buffer.cpp
+  # unittests/test_dlt_parser.cpp
+)
 target_link_libraries(
   tests
   PRIVATE dlt_explorer::dlt_explorer_warnings
           dlt_explorer::dlt_explorer_options
-          dlt_explorer::sample_library
           dlt_explorer::buffer
+          # dlt_explorer::dlt_parser
           Catch2::Catch2WithMain)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
@@ -61,48 +64,48 @@ catch_discover_tests(
   OUTPUT_SUFFIX
   .xml)
 
-# Add a file containing a set of constexpr tests
-add_executable(constexpr_tests constexpr_tests.cpp)
-target_link_libraries(
-  constexpr_tests
-  PRIVATE dlt_explorer::dlt_explorer_warnings
-          dlt_explorer::dlt_explorer_options
-          dlt_explorer::sample_library
-          Catch2::Catch2WithMain)
-
-catch_discover_tests(
-  constexpr_tests
-  TEST_PREFIX
-  "constexpr."
-  REPORTER
-  XML
-  OUTPUT_DIR
-  .
-  OUTPUT_PREFIX
-  "constexpr."
-  OUTPUT_SUFFIX
-  .xml)
-
-# Disable the constexpr portion of the test, and build again this allows us to have an executable that we can debug when
-# things go wrong with the constexpr testing
-add_executable(relaxed_constexpr_tests constexpr_tests.cpp)
-target_link_libraries(
-  relaxed_constexpr_tests
-  PRIVATE dlt_explorer::dlt_explorer_warnings
-          dlt_explorer::dlt_explorer_options
-          dlt_explorer::sample_library
-          Catch2::Catch2WithMain)
-target_compile_definitions(relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
-
-catch_discover_tests(
-  relaxed_constexpr_tests
-  TEST_PREFIX
-  "relaxed_constexpr."
-  REPORTER
-  XML
-  OUTPUT_DIR
-  .
-  OUTPUT_PREFIX
-  "relaxed_constexpr."
-  OUTPUT_SUFFIX
-  .xml)
+# # Add a file containing a set of constexpr tests
+# add_executable(constexpr_tests constexpr_tests.cpp)
+# target_link_libraries(
+#   constexpr_tests
+#   PRIVATE dlt_explorer::dlt_explorer_warnings
+#           dlt_explorer::dlt_explorer_options
+#           dlt_explorer::sample_library
+#           Catch2::Catch2WithMain)
+#
+# catch_discover_tests(
+#   constexpr_tests
+#   TEST_PREFIX
+#   "constexpr."
+#   REPORTER
+#   XML
+#   OUTPUT_DIR
+#   .
+#   OUTPUT_PREFIX
+#   "constexpr."
+#   OUTPUT_SUFFIX
+#   .xml)
+#
+# # Disable the constexpr portion of the test, and build again this allows us to have an executable that we can debug when
+# # things go wrong with the constexpr testing
+# add_executable(relaxed_constexpr_tests constexpr_tests.cpp)
+# target_link_libraries(
+#   relaxed_constexpr_tests
+#   PRIVATE dlt_explorer::dlt_explorer_warnings
+#           dlt_explorer::dlt_explorer_options
+#           dlt_explorer::sample_library
+#           Catch2::Catch2WithMain)
+# target_compile_definitions(relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
+#
+# catch_discover_tests(
+#   relaxed_constexpr_tests
+#   TEST_PREFIX
+#   "relaxed_constexpr."
+#   REPORTER
+#   XML
+#   OUTPUT_DIR
+#   .
+#   OUTPUT_PREFIX
+#   "relaxed_constexpr."
+#   OUTPUT_SUFFIX
+#   .xml)

--- a/test/unittests/test_buffer.cpp
+++ b/test/unittests/test_buffer.cpp
@@ -1,0 +1,197 @@
+#include "buffer.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <fmt/base.h>
+
+#include <cstddef>
+#include <string_view>
+#include <utility>
+
+
+struct TestType {
+  TestType() { fmt::println("------ctor"); }
+  TestType(TestType const & /*t*/) { fmt::println("------copy ctor"); }
+  TestType &operator=(TestType const &rhs) {
+    fmt::println("------copy assign");
+    TestType temp = rhs;
+    *this = std::move(temp);
+    return *this;
+  }
+  TestType(TestType && /*t*/) noexcept { fmt::println("------move ctor"); }
+  TestType &operator=(TestType && /*t*/) noexcept {
+    fmt::println("------move assign");
+    return *this;
+  }
+  ~TestType() { fmt::println("------dtor"); }
+
+  static std::string_view print() { return "test type"; }
+};
+
+template<> struct fmt::formatter<TestType> : formatter<string_view> {
+  static auto format(const TestType &testType, format_context &ctx) {
+    return fmt::format_to(ctx.out(), "{}", testType.print());
+  }
+};
+
+
+SCENARIO("Buffer constructor") {
+  GIVEN("A capacity of 1") {
+    size_t const capacity{1};
+
+    WHEN("constuctor is called") {
+      Buffer const buffer{capacity};
+
+      THEN("size and capacity change") {
+        REQUIRE(buffer.size() == 0);
+        REQUIRE(buffer.capacity() == 1);
+      }
+    }
+  }
+
+  GIVEN("A capacity of 64") {
+    size_t const capacity{64};
+
+    WHEN("constuctor is called") {
+      Buffer const buffer{capacity};
+
+      THEN("size and capacity change") {
+        REQUIRE(buffer.size() == 0);
+        REQUIRE(buffer.capacity() == 64);
+      }
+    }
+  }
+}
+
+SCENARIO("Buffer can store data.") {
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the integer 12345 is stored") {
+      int const value = 12345;
+      auto result = buffer.store(value);
+
+      THEN("characters '12345' are stored in Buffer") {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "12345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the unsigned integer 12345 is stored") {
+      unsigned int const value = 12345;
+      auto result = buffer.store(value);
+
+      THEN("characters '12345' are stored in Buffer") {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "12345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the float 1.2345 is stored") {
+      float const value = 1.2345F;
+      auto result = buffer.store(value);
+
+      THEN("characters '1.2345' are stored in Buffer") {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "1.2345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the double 1.2345 is stored") {
+      double const value = 1.2345;
+      auto result = buffer.store(value);
+
+      THEN("characters '1.2345' are stored in Buffer") {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "1.2345");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the hexadecimal 0x1a2b is stored") {
+      int const value = 0x1a2b;
+      auto result = buffer.store(Hex(value));
+
+      THEN("characters '0x1a2b' are stored in Buffer") {
+        REQUIRE(buffer.size() == 6);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "0x1a2b");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the binary 0b0101 is stored") {
+      int const value = 0b0101;
+      auto result = buffer.store(Bin(value));
+
+      THEN("characters '0b101' are stored in Buffer") {
+        REQUIRE(buffer.size() == 5);
+        REQUIRE(buffer.capacity() == 1024);
+        REQUIRE(result == "0b101");
+      }
+    }
+  }
+
+  GIVEN("A Buffer with big enough space") {
+    size_t const capacity = 1024;
+    Buffer buffer{capacity};
+
+    WHEN("the TestType is stored") {
+      buffer.store(TestType{});
+
+      THEN("no ctor are called") {}
+    }
+  }
+}
+
+// SCENARIO("Buffer can store multiple data.")
+// {
+
+//   GIVEN("A Buffer with big enough space")
+//   {
+//     size_t const capacity = 1024;
+//     Buffer buffer{ capacity };
+
+//     WHEN("the integers 123 and 456 are stored")
+//     {
+//       int const value1 = 123;
+//       int const value2 = 456;
+//       auto result = buffer.store(value1, value2);
+
+//       THEN("characters '123 456' are stored in Buffer")
+//       {
+//         REQUIRE(buffer.size() == 5);
+//         REQUIRE(buffer.capacity() == 1024);
+//         REQUIRE(result == "123 456");
+//       }
+//     }
+//   }
+// }

--- a/test/unittests/test_dlt_parser.cpp
+++ b/test/unittests/test_dlt_parser.cpp
@@ -1,0 +1,20 @@
+#include "dlt_parser.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+SCENARIO("DLT constructor") {
+  GIVEN("A DLT file with control messages") {
+    std::filesystem::path const path{"testfile.dlt"};
+
+    WHEN("constuctor is called") {
+      DLT const buffer{path};
+
+      THEN("size and capacity change") {
+        // REQUIRE(buffer.size() == 0);
+        // REQUIRE(buffer.capacity() == 1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Format test_buffer.cpp and moved test_dlt_parser.cpp to unittests dir.

Disabled constexpr tests since they are related to the template and might be used later as reference.