### PR TITLE
Build libs as shared when IPO enabled

### DIFF
--- a/.devcontainer/ubuntu.dockerfile
+++ b/.devcontainer/ubuntu.dockerfile
@@ -7,7 +7,7 @@ RUN apt update && export DEBIAN_FRONTEND=noninteractive && \
   apt upgrade -y && \
   apt install -y --no-install-recommends \
     sudo  software-properties-common vim less openssl unzip \
-    wget git curl gzip tar ninja-build
+    wget git curl gzip tar ninja-build openssh-client
 
 # Install gcc
 RUN apt install -y --no-install-recommends gcc g++ gdb

--- a/.github/workflows/auto-clang-format.yml
+++ b/.github/workflows/auto-clang-format.yml
@@ -1,5 +1,7 @@
 name: auto-clang-format
 on: [pull_request]
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -7,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.head_ref }}
     - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
         build_shared:
           - OFF
 
-        exclude:
-          # mingw is determined by this author to be too buggy to support
-          - os: windows-latest
-            compiler: gcc-14
+        # exclude:
+        #   # mingw is determined by this author to be too buggy to support
+        #   - os: windows-latest
+        #     compiler: gcc-14
 
         include:
           # Add appropriate variables for gcov version required. This will intentionally break
@@ -64,58 +64,58 @@ jobs:
             enable_ipo: Off
             gcov_executable: "llvm-cov gcov"
 
-          - os: macos-latest
-            enable_ipo: Off
-
-          # Set up preferred package generators, for given build configurations
-          - build_type: Release
-            packaging_maintainer_mode: On
-            package_generator: TBZ2
-
-          # This exists solely to make sure a non-multiconfig build works
-          - os: ubuntu-latest
-            compiler: gcc-14
-            generator: "Unix Makefiles"
-            build_type: Debug
-            gcov_executable: gcov-14
-            packaging_maintainer_mode: On
-            enable_ipo: Off
-
-          # Windows msvc builds
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            build_type: Debug
-            packaging_maintainer_mode: On
-            enable_ipo: On
-
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            build_type: Release
-            packaging_maintainer_mode: On
-            enable_ipo: On
-
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            build_type: Debug
-            packaging_maintainer_mode: Off
-
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            build_type: Release
-            packaging_maintainer_mode: Off
-            package_generator: ZIP
-
-          - os: windows-latest
-            compiler: msvc
-            generator: "Visual Studio 17 2022"
-            build_type: Release
-            packaging_maintainer_mode: On
-            enable_ipo: On
-            build_shared: On
+          # - os: macos-latest
+          #   enable_ipo: Off
+          #
+          # # Set up preferred package generators, for given build configurations
+          # - build_type: Release
+          #   packaging_maintainer_mode: On
+          #   package_generator: TBZ2
+          #
+          # # This exists solely to make sure a non-multiconfig build works
+          # - os: ubuntu-latest
+          #   compiler: gcc-14
+          #   generator: "Unix Makefiles"
+          #   build_type: Debug
+          #   gcov_executable: gcov-14
+          #   packaging_maintainer_mode: On
+          #   enable_ipo: Off
+          #
+          # # Windows msvc builds
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   build_type: Debug
+          #   packaging_maintainer_mode: On
+          #   enable_ipo: On
+          #
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   build_type: Release
+          #   packaging_maintainer_mode: On
+          #   enable_ipo: On
+          #
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   build_type: Debug
+          #   packaging_maintainer_mode: Off
+          #
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   build_type: Release
+          #   packaging_maintainer_mode: Off
+          #   package_generator: ZIP
+          #
+          # - os: windows-latest
+          #   compiler: msvc
+          #   generator: "Visual Studio 17 2022"
+          #   build_type: Release
+          #   packaging_maintainer_mode: On
+          #   enable_ipo: On
+          #   build_shared: On
 
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # Cache files
 examples/index/
+
+# CMake generated files
+__cmake_systeminformation/

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -151,6 +151,10 @@ macro(dlt_explorer_global_options)
     message("${dlt_explorer_ENABLE_HARDENING} ${ENABLE_UBSAN_MINIMAL_RUNTIME} ${dlt_explorer_ENABLE_SANITIZER_UNDEFINED}")
     dlt_explorer_enable_hardening(dlt_explorer_options ON ${ENABLE_UBSAN_MINIMAL_RUNTIME})
   endif()
+
+  if(dlt_explorer_ENABLE_DLT_DAEMON)
+    option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+  endif()
 endmacro()
 
 macro(dlt_explorer_local_options)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Used for quickly building locally for clang and gcc
+
+set -xeuo pipefail
+
+BUILD=out/build
+CONFIGURE_OPTIONS=""
+BUILD_OPTIONS="-- -v"
+TARGET=all
+
+# rm -rf out/build
+# rm -f $BUILD/unixlike-clang-debug/CMakeCache.txt $BUILD/unixlike-gcc-debug/CMakeCache.txt
+
+cmake --preset=unixlike-clang-debug $CONFIGURE_OPTIONS
+echo "######### clang configure #########"
+
+cmake --build $BUILD/unixlike-clang-debug --target $TARGET $BUILD_OPTIONS
+echo "######### clang build #########"
+
+cmake --preset=unixlike-gcc-debug $CONFIGURE_OPTIONS
+echo "######### gcc configure #########"
+
+cmake --build $BUILD/unixlike-gcc-debug --target $TARGET $BUILD_OPTIONS
+echo "######### gcc build #########"
+
+$BUILD/unixlike-gcc-debug/test/tests

--- a/cmake/InterproceduralOptimization.cmake
+++ b/cmake/InterproceduralOptimization.cmake
@@ -3,6 +3,12 @@ macro(dlt_explorer_enable_ipo)
   check_ipo_supported(RESULT result OUTPUT output)
   if(result)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+    # Force build of libs as shared when LTO is enabled. Since static libs
+    # include the object files of its dependencies this means that all the
+    # dependencies need to be compiled with LTO as well which cannot be
+    # guaranteed for external dependencies
+    option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
   else()
     message(SEND_ERROR "IPO is not supported: ${output}")
   endif()

--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -3,8 +3,7 @@
 #include <fmt/base.h>
 #include <iterator>
 
-[[nodiscard]] auto sum_values(const uint8_t *Data, size_t Size)
-{
+[[nodiscard]] auto sum_values(const uint8_t *Data, size_t Size) {
   constexpr auto scale = 1000;
 
   int value = 0;
@@ -16,8 +15,7 @@
 
 // Fuzzer that attempts to invoke undefined behavior for signed integer overflow
 // cppcheck-suppress unusedFunction symbolName=LLVMFuzzerTestOneInput
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
-{
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   fmt::print("Value sum: {}, len{}\n", sum_values(Data, Size), Size);
   return 0;
 }

--- a/include/dlt_explorer/sample_library.hpp
+++ b/include/dlt_explorer/sample_library.hpp
@@ -5,8 +5,7 @@
 
 [[nodiscard]] SAMPLE_LIBRARY_EXPORT int factorial(int) noexcept;
 
-[[nodiscard]] constexpr int factorial_constexpr(int input) noexcept
-{
+[[nodiscard]] constexpr int factorial_constexpr(int input) noexcept {
   if (input == 0) { return 1; }
 
   return input * factorial_constexpr(input - 1);

--- a/src/adapter/CMakeLists.txt
+++ b/src/adapter/CMakeLists.txt
@@ -27,8 +27,8 @@ include(GenerateExportHeader)
 generate_export_header(adapter)
 
 target_include_directories(adapter
-    PUBLIC
-      ${CMAKE_CURRENT_BINARY_DIR}
+  PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(adapter
   PRIVATE

--- a/src/adapter/with_dlt_daemon/src/adapter.cpp
+++ b/src/adapter/with_dlt_daemon/src/adapter.cpp
@@ -9,7 +9,7 @@ constexpr int DLT_DAEMON_TEXTSIZE = 10024;
 
 void parse_dlt_daemon(std::filesystem::path const &path) {
   DltFile file;
-  int const verbose{ 0 };
+  int const verbose{0};
   static std::array<char, DLT_DAEMON_TEXTSIZE> text;
   // static char text[DLT_DAEMON_TEXTSIZE];
 

--- a/src/buffer/CMakeLists.txt
+++ b/src/buffer/CMakeLists.txt
@@ -1,20 +1,8 @@
-add_library(buffer)
+add_library(buffer src/buffer.cpp)
 add_library(dlt_explorer::buffer ALIAS buffer)
 
 include(GenerateExportHeader)
 generate_export_header(buffer)
-
-target_sources(
-  buffer
-  PRIVATE src/buffer.cpp
-  PUBLIC
-    FILE_SET HEADERS
-      FILES include/buffer.h
-    FILE_SET generated_headers
-      TYPE HEADERS
-      BASE_DIRS $<TARGET_PROPERTY:buffer,BINARY_DIR>
-      FILES ${CMAKE_CURRENT_BINARY_DIR}/buffer_export.h
-)
 
 target_include_directories(buffer
   PUBLIC

--- a/src/dlt_parser/src/dlt_parser.cpp
+++ b/src/dlt_parser/src/dlt_parser.cpp
@@ -61,7 +61,7 @@ T dlt_msg_read_value(std::string_view &payload) {
   if (payload.size() < sizeof(T)) { throw std::runtime_error("Payload size is less than expected"); }
 
   T value;
-  std::memcpy(&value, payload.data(), sizeof(value));
+  std::memcpy(&value, payload.data(), sizeof(value));// NOLINT(bugprone-suspicious-stringview-data-usage)
   payload.remove_prefix(sizeof(T));
   return value;
 }

--- a/src/ftxui_sample/main.cpp
+++ b/src/ftxui_sample/main.cpp
@@ -31,14 +31,15 @@
 #include <utility>
 #include <vector>
 
-template<std::size_t Width, std::size_t Height> struct GameBoard {
+template<std::size_t Width, std::size_t Height>
+struct GameBoard {
   static constexpr std::size_t width = Width;
   static constexpr std::size_t height = Height;
 
   std::array<std::array<std::string, height>, width> strings;
   std::array<std::array<bool, height>, width> values{};
 
-  std::size_t move_count{ 0 };
+  std::size_t move_count{0};
 
   std::string &get_string(std::size_t cur_x, std::size_t cur_y) { return strings.at(cur_x).at(cur_y); }
 
@@ -139,7 +140,7 @@ void consequence_game() {
       rows.push_back(ftxui::hbox(std::move(row)));
     }
 
-    rows.push_back(ftxui::hbox({ quit_button->Render() }));
+    rows.push_back(ftxui::hbox({quit_button->Render()}));
 
     return ftxui::vbox(std::move(rows));
   };
@@ -148,7 +149,7 @@ void consequence_game() {
   static constexpr int randomization_iterations = 100;
   static constexpr int random_seed = 42;
 
-  std::mt19937 gen32{ random_seed };// NOLINT fixed seed
+  std::mt19937 gen32{random_seed};// NOLINT fixed seed
 
   // NOLINTNEXTLINE This cannot be const
   std::uniform_int_distribution<std::size_t> cur_x(static_cast<std::size_t>(0), game_board.width - 1);
@@ -170,9 +171,9 @@ void consequence_game() {
 }// namespace
 
 struct Color {
-  lefticus::tools::uint_np8_t R{ static_cast<std::uint8_t>(0) };
-  lefticus::tools::uint_np8_t G{ static_cast<std::uint8_t>(0) };
-  lefticus::tools::uint_np8_t B{ static_cast<std::uint8_t>(0) };
+  lefticus::tools::uint_np8_t R{static_cast<std::uint8_t>(0)};
+  lefticus::tools::uint_np8_t G{static_cast<std::uint8_t>(0)};
+  lefticus::tools::uint_np8_t B{static_cast<std::uint8_t>(0)};
 };
 
 // A simple way of representing a bitmap on screen using only characters
@@ -194,8 +195,8 @@ struct Bitmap : ftxui::Node {
         pixel.character = "▄";
         const auto &top_color = at(cur_x, cur_y * 2);
         const auto &bottom_color = at(cur_x, (cur_y * 2) + 1);
-        pixel.background_color = ftxui::Color{ top_color.R.get(), top_color.G.get(), top_color.B.get() };
-        pixel.foreground_color = ftxui::Color{ bottom_color.R.get(), bottom_color.G.get(), bottom_color.B.get() };
+        pixel.background_color = ftxui::Color{top_color.R.get(), top_color.G.get(), top_color.B.get()};
+        pixel.foreground_color = ftxui::Color{bottom_color.R.get(), bottom_color.G.get(), bottom_color.B.get()};
       }
     }
   }
@@ -284,10 +285,10 @@ void game_iteration_canvas() {
     last_time = new_time;
 
     // now actually draw the game elements
-    return ftxui::hbox({ bm | ftxui::border,
-      ftxui::vbox({ ftxui::text("Frame: " + std::to_string(counter)),
+    return ftxui::hbox({bm | ftxui::border,
+      ftxui::vbox({ftxui::text("Frame: " + std::to_string(counter)),
         ftxui::text("FPS: " + std::to_string(fps)),
-        small_bm | ftxui::border }) });
+        small_bm | ftxui::border})});
   };
 
   auto renderer = ftxui::Renderer(make_layout);
@@ -315,8 +316,7 @@ void game_iteration_canvas() {
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char **argv) {
   try {
-    CLI::App app{ fmt::format(
-      "{} version {}", dlt_explorer::cmake::project_name, dlt_explorer::cmake::project_version) };
+    CLI::App app{fmt::format("{} version {}", dlt_explorer::cmake::project_name, dlt_explorer::cmake::project_version)};
 
     std::optional<std::string> message;
     app.add_option("-m,--message", message, "A message to print back out");

--- a/test/constexpr_tests.cpp
+++ b/test/constexpr_tests.cpp
@@ -2,8 +2,7 @@
 
 #include <dlt_explorer/sample_library.hpp>
 
-TEST_CASE("Factorials are computed with constexpr", "[factorial]")
-{
+TEST_CASE("Factorials are computed with constexpr", "[factorial]") {
   STATIC_REQUIRE(factorial_constexpr(0) == 1);
   STATIC_REQUIRE(factorial_constexpr(1) == 1);
   STATIC_REQUIRE(factorial_constexpr(2) == 2);


### PR DESCRIPTION
When building static libs since the generated archive includes the
object files of its dependencies it means that those too need to be
compiled with LTO but if the lib includes an external dependency this
fails because those are not built with LTO. It works with shared because
each .so object is built from a single object file.