### PR TITLE
Reorganize benchmarks by operation with canonical parity IDs (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Run benchmarks:
 cargo bench
 ```
 
+Benchmark parity naming is frozen and documented in [docs/benchmark-parity.md](docs/benchmark-parity.md).
+
 ## License
 
 This project is licensed under the MIT License. See `LICENSE` for details.

--- a/benches/dlt.rs
+++ b/benches/dlt.rs
@@ -1,119 +1,13 @@
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use dlt_explorer::dlt::v1::framer as v1_framer;
-use dlt_explorer::dlt::v2::framer as v2_framer;
-use dlt_explorer::dlt::v2::Dlt;
-use dlt_explorer::dlt::v2::test_helpers::V2MessageBuilder;
-use std::hint::black_box;
-use std::io::Write;
-use std::path::PathBuf;
+mod operations;
 
-/// Generate a synthetic v2 DLT file with `count` messages, returning its path
-/// and byte size.
-fn generate_v2_file(dir: &std::path::Path, count: usize) -> (PathBuf, u64) {
-    let path = dir.join("bench_100k.dlt");
-    let mut f = std::fs::File::create(&path).expect("create bench file");
-    for i in 0..count {
-        let msg = V2MessageBuilder::new()
-            .with_apid("BNCH")
-            .with_ctid("PERF")
-            .with_ecu("ECU1")
-            .with_storage_timestamp(1000 + (i as u32 / 1000), (i as u32 % 1000) * 1_000_000)
-            .with_timestamp_ns(i as u64 * 1_000_000)
-            .with_verbose_string("benchmark payload data")
-            .build();
-        f.write_all(&msg).expect("write bench message");
-    }
-    f.flush().expect("flush bench file");
-    let size = path.metadata().expect("bench file metadata").len();
-    (path, size)
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn bench_operations(c: &mut Criterion) {
+    operations::scan_frames::bench(c);
+    operations::parse_header::bench(c);
+    operations::decode_payload::bench(c);
+    operations::open_file::bench(c);
 }
 
-fn bench_v2_open(c: &mut Criterion) {
-    let dir = tempfile::tempdir().expect("create temp dir");
-    let (path, file_size) = generate_v2_file(dir.path(), 100_000);
-
-    let mut group = c.benchmark_group("dlt_parsing");
-    group.throughput(Throughput::Bytes(file_size));
-    group.bench_function(BenchmarkId::new("v2_open", "100k_rows"), |b| {
-        b.iter(|| Dlt::open(vec![path.clone()]).unwrap());
-    });
-    group.finish();
-}
-
-fn minimal_v1_frame_with_storage_ecu(storage_ecu: &[u8; 4]) -> Vec<u8> {
-    let mut buf = Vec::new();
-    buf.extend_from_slice(b"DLT\x01");
-    buf.extend_from_slice(&100u32.to_le_bytes());
-    buf.extend_from_slice(&500u32.to_le_bytes());
-    buf.extend_from_slice(storage_ecu);
-
-    let htyp: u8 = 1 << 5;
-    buf.push(htyp);
-    buf.push(0);
-    let len: u16 = 4;
-    buf.extend_from_slice(&len.to_be_bytes());
-    buf
-}
-
-fn generate_v1_scan_data(count: usize, mixed_every: usize) -> Vec<u8> {
-    let mut data = Vec::with_capacity(count * 20);
-    for i in 0..count {
-        let ecu = if mixed_every > 0 && i % mixed_every == 0 {
-            b"ECU2"
-        } else {
-            b"ECU1"
-        };
-        data.extend_from_slice(&minimal_v1_frame_with_storage_ecu(ecu));
-    }
-    data
-}
-
-fn generate_v2_scan_data(count: usize, mixed_every: usize) -> Vec<u8> {
-    let mut data = Vec::new();
-    for i in 0..count {
-        let storage_ecu = if mixed_every > 0 && i % mixed_every == 0 {
-            *b"ECU2"
-        } else {
-            *b"ECU1"
-        };
-        let msg = V2MessageBuilder::new()
-            .with_storage_ecu(&storage_ecu)
-            .with_verbose_string("scan bench payload")
-            .build();
-        data.extend_from_slice(&msg);
-    }
-    data
-}
-
-fn bench_scan_frames(c: &mut Criterion) {
-    let count = 100_000usize;
-    let v1_uniform = generate_v1_scan_data(count, 0);
-    let v1_sparse_mixed = generate_v1_scan_data(count, 1000);
-    let v2_uniform = generate_v2_scan_data(count, 0);
-    let v2_sparse_mixed = generate_v2_scan_data(count, 1000);
-
-    let mut group = c.benchmark_group("scan_frames_ecu");
-    group.sample_size(50);
-    group.throughput(Throughput::Elements(count as u64));
-
-    group.bench_function(BenchmarkId::new("v1_scan", "uniform_ecu"), |b| {
-        b.iter(|| black_box(v1_framer::scan_frames(&v1_uniform, 0)));
-    });
-
-    group.bench_function(BenchmarkId::new("v1_scan", "sparse_mixed_ecu"), |b| {
-        b.iter(|| black_box(v1_framer::scan_frames(&v1_sparse_mixed, 0)));
-    });
-
-    group.bench_function(BenchmarkId::new("v2_scan", "uniform_ecu"), |b| {
-        b.iter(|| black_box(v2_framer::scan_frames(&v2_uniform, 0)));
-    });
-
-    group.bench_function(BenchmarkId::new("v2_scan", "sparse_mixed_ecu"), |b| {
-        b.iter(|| black_box(v2_framer::scan_frames(&v2_sparse_mixed, 0)));
-    });
-
-    group.finish();
-}
-
-criterion_group!(benches, bench_v2_open, bench_scan_frames);
+criterion_group!(benches, bench_operations);
 criterion_main!(benches);

--- a/benches/operations/decode_payload.rs
+++ b/benches/operations/decode_payload.rs
@@ -1,0 +1,31 @@
+use criterion::{BenchmarkId, Criterion};
+use dlt_explorer::dlt::protocol::CNTI_VERBOSE;
+use dlt_explorer::dlt::v1::payload as v1_payload;
+use dlt_explorer::dlt::v2::payload as v2_payload;
+use std::hint::black_box;
+
+use super::fixtures::{SHARED_SCENARIOS, build_v1_verbose_payload, payload_text};
+
+pub fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_payload");
+
+    for spec in SHARED_SCENARIOS {
+        let mut raw = build_v1_verbose_payload(payload_text(spec));
+        if spec.truncated_tail && !raw.is_empty() {
+            raw.pop();
+        }
+
+        let htyp_v1_verbose_be: u8 = (1 << 5) | 0x01 | 0x02;
+        let msin_v1_verbose: u8 = 0x01;
+
+        group.bench_function(BenchmarkId::new("v1_decode_payload", spec.name), |b| {
+            b.iter(|| black_box(v1_payload::decode_payload(htyp_v1_verbose_be, msin_v1_verbose, &raw)));
+        });
+
+        group.bench_function(BenchmarkId::new("v2_decode_payload", spec.name), |b| {
+            b.iter(|| black_box(v2_payload::decode_payload(CNTI_VERBOSE, &raw)));
+        });
+    }
+
+    group.finish();
+}

--- a/benches/operations/fixtures.rs
+++ b/benches/operations/fixtures.rs
@@ -1,0 +1,147 @@
+use dlt_explorer::dlt::payload::{DLT_SCOD_UTF8, DLT_TYPE_INFO_STRG};
+use dlt_explorer::dlt::v2::test_helpers::V2MessageBuilder;
+
+#[derive(Clone, Copy)]
+pub struct ScenarioSpec {
+    pub name: &'static str,
+    pub count: usize,
+    pub mixed_every: usize,
+    pub marker_in_payload: bool,
+    pub truncated_tail: bool,
+}
+
+pub const SHARED_SCENARIOS: [ScenarioSpec; 6] = [
+    ScenarioSpec {
+        name: "uniform_ecu_small",
+        count: 1_000,
+        mixed_every: 0,
+        marker_in_payload: false,
+        truncated_tail: false,
+    },
+    ScenarioSpec {
+        name: "uniform_ecu_large",
+        count: 100_000,
+        mixed_every: 0,
+        marker_in_payload: false,
+        truncated_tail: false,
+    },
+    ScenarioSpec {
+        name: "sparse_mixed_ecu_large",
+        count: 100_000,
+        mixed_every: 1_000,
+        marker_in_payload: false,
+        truncated_tail: false,
+    },
+    ScenarioSpec {
+        name: "dense_mixed_ecu_large",
+        count: 100_000,
+        mixed_every: 2,
+        marker_in_payload: false,
+        truncated_tail: false,
+    },
+    ScenarioSpec {
+        name: "marker_in_payload",
+        count: 5_000,
+        mixed_every: 0,
+        marker_in_payload: true,
+        truncated_tail: false,
+    },
+    ScenarioSpec {
+        name: "truncated_tail",
+        count: 5_000,
+        mixed_every: 0,
+        marker_in_payload: false,
+        truncated_tail: true,
+    },
+];
+
+pub fn payload_text(spec: ScenarioSpec) -> &'static str {
+    if spec.marker_in_payload {
+        "payload marker DLT\u{1} embedded"
+    } else {
+        "benchmark payload data"
+    }
+}
+
+pub fn build_v1_verbose_payload(text: &str) -> Vec<u8> {
+    let mut raw = Vec::new();
+    let type_info = DLT_TYPE_INFO_STRG | DLT_SCOD_UTF8;
+    raw.extend_from_slice(&type_info.to_be_bytes());
+    raw.extend_from_slice(&((text.len() + 1) as u16).to_be_bytes());
+    raw.extend_from_slice(text.as_bytes());
+    raw.push(0);
+    raw
+}
+
+pub fn build_v1_message(storage_ecu: [u8; 4], payload: &[u8], mcnt: u8) -> Vec<u8> {
+    let mut msg = Vec::new();
+
+    msg.extend_from_slice(b"DLT\x01");
+    msg.extend_from_slice(&100u32.to_le_bytes());
+    msg.extend_from_slice(&500u32.to_le_bytes());
+    msg.extend_from_slice(&storage_ecu);
+
+    let htyp: u8 = (1 << 5) | 0x01 | 0x02;
+    msg.push(htyp);
+    msg.push(mcnt);
+    msg.extend_from_slice(&0u16.to_be_bytes());
+    msg.push(0x01);
+    msg.push(1);
+    msg.extend_from_slice(b"BENC");
+    msg.extend_from_slice(b"SCAN");
+    msg.extend_from_slice(payload);
+
+    let len = (msg.len() - 16) as u16;
+    let len_off = 16 + 2;
+    msg[len_off..len_off + 2].copy_from_slice(&len.to_be_bytes());
+    msg
+}
+
+pub fn build_v2_message(storage_ecu: [u8; 4], payload_text: &str) -> Vec<u8> {
+    V2MessageBuilder::new()
+        .with_storage_ecu(&storage_ecu)
+        .with_apid("BENC")
+        .with_ctid("SCAN")
+        .with_verbose_string(payload_text)
+        .build()
+}
+
+pub fn build_v1_dataset(spec: ScenarioSpec) -> Vec<u8> {
+    let payload = build_v1_verbose_payload(payload_text(spec));
+    let mut data = Vec::new();
+
+    for i in 0..spec.count {
+        let storage_ecu = if spec.mixed_every > 0 && i % spec.mixed_every == 0 {
+            *b"ECU2"
+        } else {
+            *b"ECU1"
+        };
+        data.extend_from_slice(&build_v1_message(storage_ecu, &payload, (i % 255) as u8));
+    }
+
+    if spec.truncated_tail && data.len() > 12 {
+        data.truncate(data.len() - 12);
+    }
+
+    data
+}
+
+pub fn build_v2_dataset(spec: ScenarioSpec) -> Vec<u8> {
+    let text = payload_text(spec);
+    let mut data = Vec::new();
+
+    for i in 0..spec.count {
+        let storage_ecu = if spec.mixed_every > 0 && i % spec.mixed_every == 0 {
+            *b"ECU2"
+        } else {
+            *b"ECU1"
+        };
+        data.extend_from_slice(&build_v2_message(storage_ecu, text));
+    }
+
+    if spec.truncated_tail && data.len() > 12 {
+        data.truncate(data.len() - 12);
+    }
+
+    data
+}

--- a/benches/operations/mod.rs
+++ b/benches/operations/mod.rs
@@ -1,0 +1,5 @@
+pub mod decode_payload;
+pub mod fixtures;
+pub mod open_file;
+pub mod parse_header;
+pub mod scan_frames;

--- a/benches/operations/open_file.rs
+++ b/benches/operations/open_file.rs
@@ -1,0 +1,34 @@
+use criterion::{BenchmarkId, Criterion, Throughput};
+use dlt_explorer::dlt::v1::Dlt as V1Dlt;
+use dlt_explorer::dlt::v2::Dlt as V2Dlt;
+use std::fs;
+
+use super::fixtures::{SHARED_SCENARIOS, build_v1_dataset, build_v2_dataset};
+
+pub fn bench(c: &mut Criterion) {
+    let tempdir = tempfile::tempdir().expect("create open_file tempdir");
+    let mut group = c.benchmark_group("open_file");
+
+    for spec in SHARED_SCENARIOS {
+        let v1_data = build_v1_dataset(spec);
+        let v2_data = build_v2_dataset(spec);
+
+        let v1_path = tempdir.path().join(format!("v1_{}.dlt", spec.name));
+        let v2_path = tempdir.path().join(format!("v2_{}.dlt", spec.name));
+
+        fs::write(&v1_path, &v1_data).expect("write v1 open_file fixture");
+        fs::write(&v2_path, &v2_data).expect("write v2 open_file fixture");
+
+        group.throughput(Throughput::Bytes(v1_data.len() as u64));
+        group.bench_function(BenchmarkId::new("v1_open_file", spec.name), |b| {
+            b.iter(|| V1Dlt::open(vec![v1_path.clone()]).unwrap());
+        });
+
+        group.throughput(Throughput::Bytes(v2_data.len() as u64));
+        group.bench_function(BenchmarkId::new("v2_open_file", spec.name), |b| {
+            b.iter(|| V2Dlt::open(vec![v2_path.clone()]).unwrap());
+        });
+    }
+
+    group.finish();
+}

--- a/benches/operations/parse_header.rs
+++ b/benches/operations/parse_header.rs
@@ -1,0 +1,36 @@
+use criterion::{BenchmarkId, Criterion};
+use dlt_explorer::dlt::v1::header::parse_v1_header;
+use dlt_explorer::dlt::v2::header::parse_v2_header;
+use std::hint::black_box;
+
+use super::fixtures::{SHARED_SCENARIOS, build_v1_dataset, build_v2_dataset};
+
+pub fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_header");
+
+    for spec in SHARED_SCENARIOS {
+        let v1_data = build_v1_dataset(spec);
+        let v2_data = build_v2_dataset(spec);
+
+        let v1_msg = if v1_data.len() > 16 {
+            &v1_data[16..]
+        } else {
+            &v1_data[..]
+        };
+        let v2_msg = if v2_data.len() > 16 {
+            &v2_data[16..]
+        } else {
+            &v2_data[..]
+        };
+
+        group.bench_function(BenchmarkId::new("v1_parse_header", spec.name), |b| {
+            b.iter(|| black_box(parse_v1_header(v1_msg)));
+        });
+
+        group.bench_function(BenchmarkId::new("v2_parse_header", spec.name), |b| {
+            b.iter(|| black_box(parse_v2_header(v2_msg)));
+        });
+    }
+
+    group.finish();
+}

--- a/benches/operations/scan_frames.rs
+++ b/benches/operations/scan_frames.rs
@@ -1,0 +1,27 @@
+use criterion::{BenchmarkId, Criterion, Throughput};
+use dlt_explorer::dlt::v1::framer as v1_framer;
+use dlt_explorer::dlt::v2::framer as v2_framer;
+use std::hint::black_box;
+
+use super::fixtures::{SHARED_SCENARIOS, build_v1_dataset, build_v2_dataset};
+
+pub fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_frames");
+
+    for spec in SHARED_SCENARIOS {
+        let v1_data = build_v1_dataset(spec);
+        let v2_data = build_v2_dataset(spec);
+
+        group.throughput(Throughput::Elements(spec.count as u64));
+
+        group.bench_function(BenchmarkId::new("v1_scan_frames", spec.name), |b| {
+            b.iter(|| black_box(v1_framer::scan_frames(&v1_data, 0)));
+        });
+
+        group.bench_function(BenchmarkId::new("v2_scan_frames", spec.name), |b| {
+            b.iter(|| black_box(v2_framer::scan_frames(&v2_data, 0)));
+        });
+    }
+
+    group.finish();
+}

--- a/docs/benchmark-parity.md
+++ b/docs/benchmark-parity.md
@@ -1,0 +1,21 @@
+# Benchmark parity naming contract
+
+This repository uses an operation-first benchmark layout under a single Criterion entrypoint in `benches/dlt.rs`.
+
+## Frozen naming convention
+
+Benchmark IDs are frozen to the following canonical format:
+
+- Group: operation name (`scan_frames`, `parse_header`, `decode_payload`, `open_file`)
+- Benchmark identifier: `<protocol>_<operation>` (`v1_scan_frames`, `v2_scan_frames`, etc.)
+- Benchmark parameter: shared scenario name (`uniform_ecu_small`, `uniform_ecu_large`, `sparse_mixed_ecu_large`, `dense_mixed_ecu_large`, `marker_in_payload`, `truncated_tail`)
+
+Example:
+
+- `BenchmarkId::new("v1_scan_frames", "uniform_ecu_large")`
+- `BenchmarkId::new("v2_decode_payload", "marker_in_payload")`
+
+## Migration note
+
+Issue #74 performed the one-time rename from legacy benchmark IDs to canonical IDs.
+Future additions must follow this contract and be declared in `parity_manifest.toml`.

--- a/parity_manifest.toml
+++ b/parity_manifest.toml
@@ -1,16 +1,148 @@
 # Parity contract for shared v1/v2 scenarios.
 
 [[benchmark_pairs]]
-scenario = "scan_uniform_ecu"
-v1_benchmark = "v1_scan"
-v2_benchmark = "v2_scan"
-parameter = "uniform_ecu"
+scenario = "scan_uniform_ecu_small"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "uniform_ecu_small"
 
 [[benchmark_pairs]]
-scenario = "scan_sparse_mixed_ecu"
-v1_benchmark = "v1_scan"
-v2_benchmark = "v2_scan"
-parameter = "sparse_mixed_ecu"
+scenario = "scan_uniform_ecu_large"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "uniform_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "scan_sparse_mixed_ecu_large"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "sparse_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "scan_dense_mixed_ecu_large"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "dense_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "scan_marker_in_payload"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "marker_in_payload"
+
+[[benchmark_pairs]]
+scenario = "scan_truncated_tail"
+v1_benchmark = "v1_scan_frames"
+v2_benchmark = "v2_scan_frames"
+parameter = "truncated_tail"
+
+[[benchmark_pairs]]
+scenario = "parse_header_uniform_ecu_small"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "uniform_ecu_small"
+
+[[benchmark_pairs]]
+scenario = "parse_header_uniform_ecu_large"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "uniform_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "parse_header_sparse_mixed_ecu_large"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "sparse_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "parse_header_dense_mixed_ecu_large"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "dense_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "parse_header_marker_in_payload"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "marker_in_payload"
+
+[[benchmark_pairs]]
+scenario = "parse_header_truncated_tail"
+v1_benchmark = "v1_parse_header"
+v2_benchmark = "v2_parse_header"
+parameter = "truncated_tail"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_uniform_ecu_small"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "uniform_ecu_small"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_uniform_ecu_large"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "uniform_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_sparse_mixed_ecu_large"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "sparse_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_dense_mixed_ecu_large"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "dense_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_marker_in_payload"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "marker_in_payload"
+
+[[benchmark_pairs]]
+scenario = "decode_payload_truncated_tail"
+v1_benchmark = "v1_decode_payload"
+v2_benchmark = "v2_decode_payload"
+parameter = "truncated_tail"
+
+[[benchmark_pairs]]
+scenario = "open_file_uniform_ecu_small"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "uniform_ecu_small"
+
+[[benchmark_pairs]]
+scenario = "open_file_uniform_ecu_large"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "uniform_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "open_file_sparse_mixed_ecu_large"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "sparse_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "open_file_dense_mixed_ecu_large"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "dense_mixed_ecu_large"
+
+[[benchmark_pairs]]
+scenario = "open_file_marker_in_payload"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "marker_in_payload"
+
+[[benchmark_pairs]]
+scenario = "open_file_truncated_tail"
+v1_benchmark = "v1_open_file"
+v2_benchmark = "v2_open_file"
+parameter = "truncated_tail"
 
 [[test_pairs]]
 scenario = "single_frame"

--- a/src/dlt/v2/mod.rs
+++ b/src/dlt/v2/mod.rs
@@ -1,5 +1,5 @@
 pub mod framer;
-mod header;
+pub mod header;
 pub mod payload;
 
 use anyhow::Result;

--- a/tests/parity_contract.rs
+++ b/tests/parity_contract.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -31,6 +32,32 @@ fn load_manifest() -> ParityManifest {
         .expect("failed to parse parity_manifest.toml as ParityManifest")
 }
 
+fn collect_rs_files(root: &Path, out: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(root).expect("failed to read benchmark directory");
+    for entry in entries {
+        let path = entry.expect("failed to read benchmark entry").path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn load_bench_sources() -> String {
+    let mut files = Vec::new();
+    collect_rs_files(Path::new("benches"), &mut files);
+    files.sort();
+
+    files
+        .into_iter()
+        .map(|path| {
+            fs::read_to_string(&path).unwrap_or_else(|_| panic!("failed to read {}", path.display()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[test]
 fn parity_manifest_contract_is_satisfied() {
     let manifest = load_manifest();
@@ -43,7 +70,7 @@ fn parity_manifest_contract_is_satisfied() {
         "parity manifest must define at least one test pair"
     );
 
-    let benches_src = fs::read_to_string("benches/dlt.rs").expect("failed to read benches/dlt.rs");
+    let benches_src = load_bench_sources();
     let v1_tests_src = fs::read_to_string("src/dlt/v1/framer.rs")
         .expect("failed to read src/dlt/v1/framer.rs");
     let v2_tests_src = fs::read_to_string("src/dlt/v2/framer.rs")
@@ -69,13 +96,21 @@ fn parity_manifest_contract_is_satisfied() {
             pair.v2_benchmark, pair.parameter
         );
 
-        if !benches_src.contains(&v1_expected) {
+        let v1_modular_expected = format!("BenchmarkId::new(\"{}\", spec.name)", pair.v1_benchmark);
+        let v2_modular_expected = format!("BenchmarkId::new(\"{}\", spec.name)", pair.v2_benchmark);
+        let scenario_declared = format!("name: \"{}\"", pair.parameter);
+
+        if !benches_src.contains(&v1_expected)
+            && !(benches_src.contains(&v1_modular_expected) && benches_src.contains(&scenario_declared))
+        {
             failures.push(format!(
                 "benchmark parity missing v1 side for scenario '{}' (expected {})",
                 pair.scenario, v1_expected
             ));
         }
-        if !benches_src.contains(&v2_expected) {
+        if !benches_src.contains(&v2_expected)
+            && !(benches_src.contains(&v2_modular_expected) && benches_src.contains(&scenario_declared))
+        {
             failures.push(format!(
                 "benchmark parity missing v2 side for scenario '{}' (expected {})",
                 pair.scenario, v2_expected


### PR DESCRIPTION
#74 